### PR TITLE
feat: add Project Scale display to analyze output

### DIFF
--- a/domain/analyze.go
+++ b/domain/analyze.go
@@ -127,6 +127,10 @@ type AnalyzeSummary struct {
 	MediumCouplingClasses int     `json:"medium_coupling_classes" yaml:"medium_coupling_classes"` // 3 < CBO ≤ 7 (Medium Risk)
 	AverageCoupling       float64 `json:"average_coupling" yaml:"average_coupling"`
 
+	// Project scale
+	TotalLOC     int    `json:"total_loc" yaml:"total_loc"`
+	ProjectScale string `json:"project_scale" yaml:"project_scale"`
+
 	// Overall health score (0-100)
 	HealthScore int    `json:"health_score" yaml:"health_score"`
 	Grade       string `json:"grade" yaml:"grade"` // A, B, C, D, F
@@ -440,6 +444,7 @@ func (s *AnalyzeSummary) CalculateHealthScore() error {
 		score = MinimumScore
 	}
 	s.HealthScore = score
+	s.ProjectScale = s.classifyScale()
 
 	// Grade mapping
 	switch {
@@ -498,6 +503,22 @@ func GetGradeFromScore(score int) string {
 		return "D"
 	default:
 		return "F"
+	}
+}
+
+// classifyScale returns a project scale label based on the number of analyzed files
+func (s *AnalyzeSummary) classifyScale() string {
+	switch {
+	case s.AnalyzedFiles >= 1000:
+		return "Enterprise"
+	case s.AnalyzedFiles >= 200:
+		return "Large"
+	case s.AnalyzedFiles >= 50:
+		return "Medium"
+	case s.AnalyzedFiles >= 10:
+		return "Small"
+	default:
+		return "Micro"
 	}
 }
 

--- a/domain/analyze_test.go
+++ b/domain/analyze_test.go
@@ -84,6 +84,39 @@ func TestCalculateHealthScore_CyclePenaltyLogFloor(t *testing.T) {
 	}
 }
 
+func TestClassifyScale(t *testing.T) {
+	tests := []struct {
+		name          string
+		analyzedFiles int
+		wantScale     string
+	}{
+		{"zero files", 0, "Micro"},
+		{"9 files (upper Micro)", 9, "Micro"},
+		{"10 files (lower Small)", 10, "Small"},
+		{"49 files (upper Small)", 49, "Small"},
+		{"50 files (lower Medium)", 50, "Medium"},
+		{"199 files (upper Medium)", 199, "Medium"},
+		{"200 files (lower Large)", 200, "Large"},
+		{"999 files (upper Large)", 999, "Large"},
+		{"1000 files (Enterprise)", 1000, "Enterprise"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := &AnalyzeSummary{
+				AnalyzedFiles: tt.analyzedFiles,
+			}
+			if err := s.CalculateHealthScore(); err != nil {
+				t.Fatalf("CalculateHealthScore() error: %v", err)
+			}
+			if s.ProjectScale != tt.wantScale {
+				t.Errorf("ProjectScale = %q, want %q for %d files",
+					s.ProjectScale, tt.wantScale, tt.analyzedFiles)
+			}
+		})
+	}
+}
+
 func TestCalculateHealthScore_MSDPenalty(t *testing.T) {
 	tests := []struct {
 		name    string

--- a/service/html_formatter.go
+++ b/service/html_formatter.go
@@ -320,6 +320,7 @@ const htmlTemplate = `<!DOCTYPE html>
             <div class="score-badge {{gradeClass .Summary.Grade}}">
                 Health Score: {{.Summary.HealthScore}}/100 (Grade: {{.Summary.Grade}})
             </div>
+            <p class="subtitle">Project Scale: {{.Summary.ProjectScale}} ({{.Summary.AnalyzedFiles}} files, {{.Summary.TotalFunctions}} functions{{if gt .Summary.TotalLOC 0}}, {{.Summary.TotalLOC}} LOC{{end}})</p>
         </div>
 
         <div class="tabs">

--- a/service/output_formatter.go
+++ b/service/output_formatter.go
@@ -226,6 +226,7 @@ func BuildAnalyzeSummary(
 			summary.ClonePairs = cloneResponse.Statistics.TotalClonePairs
 			summary.CloneGroups = cloneResponse.Statistics.TotalCloneGroups
 			summary.CodeDuplication = calculateDuplicationPercentage(cloneResponse)
+			summary.TotalLOC = cloneResponse.Statistics.LinesAnalyzed
 		}
 	}
 
@@ -262,6 +263,13 @@ func FormatCLISummary(summary *domain.AnalyzeSummary, duration time.Duration) st
 	w := &strings.Builder{}
 
 	fmt.Fprintf(w, "\n\U0001F4CA Analysis Summary:\n")
+	if summary.TotalLOC > 0 {
+		fmt.Fprintf(w, "Project Scale: %s (%d files, %d functions, %d LOC)\n",
+			summary.ProjectScale, summary.AnalyzedFiles, summary.TotalFunctions, summary.TotalLOC)
+	} else {
+		fmt.Fprintf(w, "Project Scale: %s (%d files, %d functions)\n",
+			summary.ProjectScale, summary.AnalyzedFiles, summary.TotalFunctions)
+	}
 	fmt.Fprintf(w, "Health Score: %d/100 (Grade: %s)\n", summary.HealthScore, summary.Grade)
 	fmt.Fprintf(w, "Total time: %dms\n", duration.Milliseconds())
 


### PR DESCRIPTION
## Summary
- Health Score の直後に **Project Scale** 行を追加し、リポジトリ規模（Micro / Small / Medium / Large / Enterprise）をファイル数に基づいて表示
- CLI・HTML・JSON/YAML 出力すべてに対応
- `classifyScale()` の境界値テスト（0, 9, 10, 49, 50, 199, 200, 999, 1000）を追加

## Test plan
- [x] `go test ./domain/ ./service/` — 既存テスト + 新規 `TestClassifyScale` が全パス
- [x] `jscan analyze test-repos/junk` → `Project Scale: Micro (4 files, 6 functions, 127 LOC)` 表示確認
- [x] `jscan analyze test-repos/express` → `Project Scale: Medium (123 files, ...)` 表示確認
- [ ] HTML レポートにスケール情報が表示されることを目視確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)