### PR TITLE
sync: catch up scoring with pyscn (initial catch-up 2/3)

### DIFF
--- a/SYNC.md
+++ b/SYNC.md
@@ -16,7 +16,7 @@ The initial catch-up must be done by **state comparison**, not by replaying indi
 1. For each target file, compare pyscn's current `origin/main` content against jscan's current content and identify missing fixes and constant changes (use the commit log only to understand the intent of a change)
 2. Split the work into one PR per area, ordered by churn:
    - **Clone detection** — **Done** (2026-06-11, compared against pyscn `73acc60`. PR: sync/catchup-clone) — covered `clone_detector.go`, `apted*.go`, the grouping strategies, `domain/clone.go`, `ast_features.go`, and newly ported `textual_similarity.go` / `syntactic_similarity.go`
-   - **Scoring** — `domain/analyze.go` (16), `domain/system_analysis.go` (9), `domain/complexity.go` (9). Goal: identical grade computation in both tools
+   - **Scoring** — **Done** (2026-06-11, compared against pyscn `8650522`. PR: sync/catchup-scoring) — covered `domain/analyze.go` (duplication 0–10% scale + group-density metric, CBO calibration, architecture score = compliance), `domain/system_analysis.go` (WeightedViolations), `domain/complexity.go` (`ModuleFunctionName`) and the `__main__` → `<module>` label migration
    - **Misc** — `dependency_graph.go`, `reachability.go`, `lsh_index.go`, `coupling_metrics.go`, and other low-commit files
 3. Once all areas are done, delete this section and update the baseline SHA to the `origin/main` HEAD used during the catch-up
 
@@ -59,7 +59,7 @@ The initial catch-up must be done by **state comparison**, not by replaying indi
 
 | pyscn | jscan | Classification | Notes |
 |---|---|---|---|
-| `domain/analyze.go` | `domain/analyze.go` | sync | Health-score computation and penalty constants. **Grade computation must match across both tools** |
+| `domain/analyze.go` | `domain/analyze.go` | sync | Health-score computation and penalty constants. **Grade computation must match across both tools**. Intentional divergence: `calculateComplexityPenalty` (jscan uses high/medium count ratio, ESLint-aligned; pyscn uses average complexity) and `calculateDeadCodePenalty` (jscan uses per-file rate) — jscan-side improvements, do not overwrite |
 | `domain/system_analysis.go` | `domain/system_analysis.go` | sync | Same as above |
 | `domain/complexity.go` | `domain/complexity.go` | case-by-case | Keep thresholds and risk-level definitions aligned |
 | `domain/clone.go` | `domain/clone.go` | case-by-case | Keep similarity thresholds and clone-type definitions aligned |
@@ -100,9 +100,21 @@ Skipped during the clone detection catch-up (2026-06-11):
 - **star_medoid graph optimization** (`buildSimilarityGraph` / `mostSimilarMedoid`) — performance-only change, structurally different from jscan's StarMedoid implementation (iterative reassignment over domain.Clone). The `averageGroupSimilarity` change to count only existing pairs was ported
 - **pyscn's removal of the content-less `ExtractFragments`** — jscan tests still use it, so both variants were kept
 
+Skipped during the scoring catch-up (2026-06-11):
+
+- **LCOM cohesion scoring** (`CohesionMediumWeight` / `CohesionSaturationRatio`, `calculateCohesionPenalty`, `CohesionScore`, the LCOM summary fields, `57fcc66`) — depends on the unported LCOM4 feature. Port together with `lcom.go` / `domain/lcom.go`
+- **Cognitive complexity / RawMetrics fields in `domain/complexity.go`** (`8aa6d21`, `ce469ce`) — unported features
+- **Mock/synthetic fixture detection** (`MockData*` fields, `15bd414`) — pyscn-specific lint feature
+- **Suggestions** (`Suggestions` field, `1eaf9f6`) — depends on unported `domain/suggestion.go`
+- **Analyze config plumbing** (`AnalyzeOutputFormatter`, `AnalyzeExecutionConfig`, `AnalyzeConfigurationLoader`, `Enabled`/`ReportUnchanged`/`Request` fields, `222d190`, `779200a`, `13644b4`, `e79a414`, `d6fd3da`, `ca75d12`) — jscan's config-loader layer differs, out of scope
+- **Architecture style presets / warn rules / neutral prefixes / cohesion-responsibility validation** (`ad79460`, `1c9839d`, `61f0431`, `3708845`, `ddcf1c5`) — jscan does not implement architecture validation (the `ArchitectureAnalysisResult` types are unused scaffolding); only the `WeightedViolations` field was ported for type alignment
+- **`AbstractClassCount`** (`f63540d`) — Python ABC detection; jscan computes abstractness its own way in `coupling_metrics.go` from TS interfaces/abstract classes
+- **Django migration exclusion / Python default patterns** (`a33f1c7`, `DefaultPythonModuleIncludePatterns`) — Python-specific
+
 ## Sync history
 
 | Date | pyscn SHA | Summary |
 |---|---|---|
 | 2026-06-11 | `f0457d7` | Set the baseline to the state jscan's initial implementation was based on (v1.4.1). The ~210 commits since then are the unported backlog targeted by the initial catch-up |
 | 2026-06-11 | `73acc60` | Initial catch-up: clone detection area done. APTED correctness fixes (ascending key roots, forest-distance subtreeCost, max(size) normalization), bounded large-tree approximation (same-shape distance, label/shape profiles), Jaccard pre-filter, Type-1 textual-match gate and Type-2 syntactic gate (ported textual/syntactic similarity), threshold recalibration (0.85/0.75/0.70/0.65), Type-3 disabled by default, overlapping-range pair rejection (isOverlappingLocation), strict-subset group member removal (group_dedup), complete_linkage rewritten as agglomerative clustering, MinLines/MinNodes 10/20, LSH auto-enable by estimated pair count, introduced `parser.OrderedChildren` |
+| 2026-06-11 | `8650522` | Initial catch-up: scoring area done. Duplication metric switched to K-Core group density (groups per 1000 lines × 20, capped at 10%) with 0–10% penalty scale (`0886cfb`, `760bc87`), CBO coupling calibration softened (medium weight 0.3, saturation 0.40, `333c9ac`, `9c84a3d`), architecture score now uses compliance directly (`3c9927c`), `WeightedViolations` exposed (`e6b9920`), module-scope label `__main__` → `<module>` via `domain.ModuleFunctionName` (`2cc013c`) |

--- a/domain/analyze.go
+++ b/domain/analyze.go
@@ -17,20 +17,26 @@ const (
 	ComplexityPenaltyLow      = 6
 
 	// Code duplication thresholds and penalties
-	DuplicationThresholdHigh   = 30.0
-	DuplicationThresholdMedium = 15.0
-	DuplicationThresholdLow    = 5.0
+	// 0% = perfect, 10% = max penalty
+	DuplicationThresholdHigh   = 10.0
+	DuplicationThresholdMedium = 5.0
+	DuplicationThresholdLow    = 0.0
 	DuplicationPenaltyHigh     = 20
 	DuplicationPenaltyMedium   = 12
 	DuplicationPenaltyLow      = 6
 
-	// CBO coupling thresholds and penalties
-	CouplingRatioHigh     = 0.30 // 30% or more classes with high coupling
-	CouplingRatioMedium   = 0.15 // 15-30% classes with high coupling
-	CouplingRatioLow      = 0.05 // 5-15% classes with high coupling
-	CouplingPenaltyHigh   = 20   // Aligned with other high penalties
-	CouplingPenaltyMedium = 12   // Aligned with other medium penalties
-	CouplingPenaltyLow    = 6    // Aligned with other low penalties
+	// K-Core group density calculation constants
+	// Group density = groups / (lines / GroupDensityLinesUnit)
+	// CodeDuplication% = min(DuplicationThresholdHigh, density * GroupDensityCoefficient)
+	GroupDensityLinesUnit   = 1000.0 // Calculate density per 1000 lines
+	GroupDensityMinLines    = 1.0    // Minimum lines in thousands (for small projects)
+	GroupDensityCoefficient = 20.0   // Multiplier to convert density to percentage
+
+	// CBO coupling scoring curve (used by calculateCouplingPenalty)
+	// Penalty grows linearly with the weighted ratio of problematic classes
+	// and saturates (reaches the max penalty) at CouplingSaturationRatio.
+	CouplingMediumWeight    = 0.3  // Medium-risk classes count 0.3 vs High = 1.0
+	CouplingSaturationRatio = 0.40 // weighted ratio at which the penalty maxes out
 
 	// Maximum penalties
 	MaxDeadCodePenalty = 20
@@ -244,15 +250,16 @@ func (s *AnalyzeSummary) calculateDeadCodePenalty(_ float64) int {
 }
 
 // calculateDuplicationPenalty calculates the penalty for code duplication (max 20)
-// Uses continuous linear function starting from 1% duplication
+// Uses continuous linear function based on defined thresholds
 func (s *AnalyzeSummary) calculateDuplicationPenalty() int {
-	// Linear penalty: starts at 1%, reaches max (20) at 20%
-	// Formula: penalty = (duplication - 1) / 19 * 20
-	if s.CodeDuplication <= 1.0 {
+	// Linear penalty: 0% = 0 penalty, 10% = max penalty (20)
+	if s.CodeDuplication <= DuplicationThresholdLow {
 		return 0
 	}
 
-	penalty := (s.CodeDuplication - 1.0) / 19.0 * 20.0
+	// Formula: penalty = (duplication - low) / (high - low) * 20
+	penaltyRange := DuplicationThresholdHigh - DuplicationThresholdLow
+	penalty := (s.CodeDuplication - DuplicationThresholdLow) / penaltyRange * 20.0
 	if penalty > 20.0 {
 		penalty = 20.0
 	}
@@ -268,13 +275,13 @@ func (s *AnalyzeSummary) calculateCouplingPenalty() int {
 	}
 
 	// Calculate combined problematic classes ratio
-	// Weight: High Risk = 1.0, Medium Risk = 0.5
-	weightedProblematicClasses := float64(s.HighCouplingClasses) + (0.5 * float64(s.MediumCouplingClasses))
+	// Weight: High Risk = 1.0, Medium Risk = CouplingMediumWeight
+	weightedProblematicClasses := float64(s.HighCouplingClasses) + (CouplingMediumWeight * float64(s.MediumCouplingClasses))
 	ratio := weightedProblematicClasses / float64(s.CBOClasses)
 
-	// Linear penalty: starts at 0%, reaches max (20) at 50%
-	// Formula: penalty = ratio / 0.50 * 20
-	penalty := ratio / 0.50 * 20.0
+	// Linear penalty: starts at 0%, reaches max (20) at CouplingSaturationRatio
+	// Formula: penalty = ratio / CouplingSaturationRatio * 20
+	penalty := ratio / CouplingSaturationRatio * 20.0
 	if penalty > 20.0 {
 		penalty = 20.0
 	}
@@ -431,8 +438,8 @@ func (s *AnalyzeSummary) CalculateHealthScore() error {
 	score -= dependencyPenalty
 
 	architecturePenalty := s.calculateArchitecturePenalty()
-	normalizedArchPenalty := normalizeToScoreBase(architecturePenalty, MaxArchitecturePenalty)
-	s.ArchitectureScore = penaltyToScore(normalizedArchPenalty, MaxScoreBase)
+	// Use compliance directly as score (98% compliance = 98 points)
+	s.ArchitectureScore = int(math.Round(s.ArchCompliance * 100))
 	score -= architecturePenalty
 
 	// Minimum score floor

--- a/domain/analyze_test.go
+++ b/domain/analyze_test.go
@@ -84,6 +84,96 @@ func TestCalculateHealthScore_CyclePenaltyLogFloor(t *testing.T) {
 	}
 }
 
+func TestCalculateHealthScore_DuplicationPenalty(t *testing.T) {
+	tests := []struct {
+		name            string
+		duplication     float64
+		wantDuplication int // expected DuplicationScore
+		wantHealth      int
+	}{
+		{
+			// 0-10% scale: 1/10*20 = 2 penalty
+			name:            "low duplication penalised from zero",
+			duplication:     1.0,
+			wantDuplication: 90,
+			wantHealth:      98,
+		},
+		{
+			// 5/10*20 = 10 penalty
+			name:            "medium duplication",
+			duplication:     5.0,
+			wantDuplication: 50,
+			wantHealth:      90,
+		},
+		{
+			// 10% reaches the max penalty (20)
+			name:            "max penalty at threshold high",
+			duplication:     10.0,
+			wantDuplication: 0,
+			wantHealth:      80,
+		},
+		{
+			name:            "no duplication no penalty",
+			duplication:     0.0,
+			wantDuplication: 100,
+			wantHealth:      100,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := &AnalyzeSummary{CodeDuplication: tt.duplication}
+			if err := s.CalculateHealthScore(); err != nil {
+				t.Fatalf("CalculateHealthScore() error: %v", err)
+			}
+			if s.DuplicationScore != tt.wantDuplication {
+				t.Errorf("DuplicationScore = %d, want %d", s.DuplicationScore, tt.wantDuplication)
+			}
+			if s.HealthScore != tt.wantHealth {
+				t.Errorf("HealthScore = %d, want %d", s.HealthScore, tt.wantHealth)
+			}
+		})
+	}
+}
+
+func TestCalculateHealthScore_CouplingCalibration(t *testing.T) {
+	// Softened CBO curve: a repo with a healthy average CBO and ~10% high-coupling
+	// classes should not floor the coupling score.
+	s := &AnalyzeSummary{
+		CBOClasses:            100,
+		HighCouplingClasses:   10, // 10%
+		MediumCouplingClasses: 20,
+		// weighted = 10 + 0.3*20 = 16; ratio = 0.16; penalty = 0.16/0.40*20 = 8
+	}
+	if err := s.CalculateHealthScore(); err != nil {
+		t.Fatalf("CalculateHealthScore() error: %v", err)
+	}
+	if s.CouplingScore != 60 { // 100 - (8/20)*100
+		t.Errorf("CouplingScore = %d, want 60", s.CouplingScore)
+	}
+	if s.HealthScore != 92 || s.Grade != "A" {
+		t.Errorf("HealthScore = %d (%s), want 92 (A)", s.HealthScore, s.Grade)
+	}
+}
+
+func TestCalculateHealthScore_ArchitectureScoreUsesCompliance(t *testing.T) {
+	s := &AnalyzeSummary{
+		ArchEnabled:    true,
+		ArchCompliance: 0.125,
+	}
+	if err := s.CalculateHealthScore(); err != nil {
+		t.Fatalf("CalculateHealthScore() error: %v", err)
+	}
+	// Compliance is used directly as the score: 0.125 * 100 = 12.5 → 13
+	if s.ArchitectureScore != 13 {
+		t.Errorf("ArchitectureScore = %d, want 13", s.ArchitectureScore)
+	}
+	// The health penalty is still (1-compliance)*MaxArchPenalty = 10.5 → 11
+	if s.HealthScore != 89 {
+		t.Errorf("HealthScore = %d, want 89", s.HealthScore)
+	}
+}
+
 func TestCalculateHealthScore_MSDPenalty(t *testing.T) {
 	tests := []struct {
 		name    string

--- a/domain/complexity.go
+++ b/domain/complexity.go
@@ -39,6 +39,11 @@ const (
 	RiskLevelHigh   RiskLevel = "high"
 )
 
+// ModuleFunctionName is the user-facing label used for module-scope (top-level) code
+// in places that key/display per-function results. The angle brackets signal that this
+// is not a real function defined in the source.
+const ModuleFunctionName = "<module>"
+
 // ComplexityRequest represents a request for complexity analysis
 type ComplexityRequest struct {
 	// Input files or directories to analyze

--- a/domain/system_analysis.go
+++ b/domain/system_analysis.go
@@ -209,9 +209,10 @@ type CouplingAnalysis struct {
 // ArchitectureAnalysisResult contains architecture validation results
 type ArchitectureAnalysisResult struct {
 	// Overall architecture compliance
-	ComplianceScore float64 // Overall compliance score (0-1, where 1.0 = 100% compliant)
-	TotalViolations int     // Total number of violations
-	TotalRules      int     // Total number of rules checked
+	ComplianceScore    float64 // Overall compliance score (0-1, where 1.0 = 100% compliant). Computed as 1 - WeightedViolations/TotalRules (clamped to [0,1]).
+	TotalViolations    int     // Raw number of violations (one per ArchitectureViolation entry).
+	WeightedViolations int     // Severity-weighted violation count used as the ComplianceScore numerator: error * 5 + warning * 1.
+	TotalRules         int     // Total number of rule invocations checked (ComplianceScore denominator).
 
 	// Layer analysis
 	LayerAnalysis          *LayerAnalysis          // Layer violation analysis

--- a/internal/analyzer/cfg_builder.go
+++ b/internal/analyzer/cfg_builder.go
@@ -5,6 +5,7 @@ import (
 	"log"
 	"strconv"
 
+	"github.com/ludo-technologies/jscan/domain"
 	"github.com/ludo-technologies/jscan/internal/parser"
 )
 
@@ -13,7 +14,6 @@ const (
 	LabelFunctionBody = "func_body"
 	LabelClassBody    = "class_body"
 	LabelUnreachable  = "unreachable"
-	LabelMainModule   = "main"
 	LabelEntry        = "ENTRY"
 	LabelExit         = "EXIT"
 
@@ -81,7 +81,7 @@ func (b *CFGBuilder) Build(node *parser.Node) (*CFG, error) {
 	}
 
 	// Initialize CFG based on node type
-	cfgName := LabelMainModule
+	cfgName := domain.ModuleFunctionName
 	if node.IsFunction() && node.Name != "" {
 		cfgName = node.Name
 	} else if node.Type == parser.NodeClass && node.Name != "" {
@@ -136,7 +136,7 @@ func (b *CFGBuilder) BuildAll(node *parser.Node) (map[string]*CFG, error) {
 	if err != nil {
 		return nil, err
 	}
-	allCFGs["__main__"] = mainCFG
+	allCFGs[domain.ModuleFunctionName] = mainCFG
 
 	// Add all function CFGs discovered during Build (via processStatement)
 	for name, cfg := range b.functionCFGs {

--- a/internal/analyzer/cfg_builder_test.go
+++ b/internal/analyzer/cfg_builder_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"testing"
 
+	"github.com/ludo-technologies/jscan/domain"
 	"github.com/ludo-technologies/jscan/internal/parser"
 )
 
@@ -117,8 +118,8 @@ func TestCFGBuilder_Build_Program(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Build failed: %v", err)
 	}
-	if cfg.Name != LabelMainModule {
-		t.Errorf("CFG name should be '%s', got %s", LabelMainModule, cfg.Name)
+	if cfg.Name != domain.ModuleFunctionName {
+		t.Errorf("CFG name should be '%s', got %s", domain.ModuleFunctionName, cfg.Name)
 	}
 }
 
@@ -851,13 +852,13 @@ func TestCFGBuilder_BuildAll(t *testing.T) {
 		t.Fatalf("BuildAll failed: %v", err)
 	}
 
-	// Should have __main__, foo, bar
+	// Should have module-scope code, foo, bar
 	if len(cfgs) < 3 {
 		t.Errorf("BuildAll should produce at least 3 CFGs, got %d", len(cfgs))
 	}
 
-	if cfgs["__main__"] == nil {
-		t.Error("Should have __main__ CFG")
+	if cfgs[domain.ModuleFunctionName] == nil {
+		t.Error("Should have module-scope CFG")
 	}
 	if cfgs["foo"] == nil {
 		t.Error("Should have 'foo' CFG")
@@ -1069,7 +1070,7 @@ func TestCFGBuilder_BuildAll_ArrowInVariable(t *testing.T) {
 		t.Fatalf("BuildAll failed: %v", err)
 	}
 
-	// Should have __main__ plus at least one function for the arrow
+	// Should have module-scope code plus at least one function for the arrow
 	if len(cfgs) < 2 {
 		t.Errorf("BuildAll should detect arrow function in variable declaration, got %d CFGs", len(cfgs))
 	}
@@ -1077,7 +1078,7 @@ func TestCFGBuilder_BuildAll_ArrowInVariable(t *testing.T) {
 	// Check that a CFG exists for the arrow function (may be named "add" or "anonymous_<line>")
 	found := false
 	for name := range cfgs {
-		if name != "__main__" {
+		if name != domain.ModuleFunctionName {
 			found = true
 			break
 		}
@@ -1103,7 +1104,7 @@ func TestCFGBuilder_BuildAll_FunctionExpressionInVariable(t *testing.T) {
 
 	found := false
 	for name := range cfgs {
-		if name != "__main__" {
+		if name != domain.ModuleFunctionName {
 			found = true
 			break
 		}
@@ -1133,7 +1134,7 @@ func TestCFGBuilder_BuildAll_AssignmentFunctionExpression(t *testing.T) {
 	// The named function expression should be found (name: "init")
 	found := false
 	for name := range cfgs {
-		if name != "__main__" {
+		if name != domain.ModuleFunctionName {
 			found = true
 			break
 		}
@@ -1158,7 +1159,7 @@ func TestCFGBuilder_BuildAll_ObjectMethods(t *testing.T) {
 		t.Fatalf("BuildAll failed: %v", err)
 	}
 
-	// Should have __main__ + at least 2 methods
+	// Should have module-scope code + at least 2 methods
 	if len(cfgs) < 3 {
 		t.Errorf("BuildAll should detect object methods, got %d CFGs (want >= 3)", len(cfgs))
 	}
@@ -1180,7 +1181,7 @@ func TestCFGBuilder_BuildAll_ExportedArrowFunction(t *testing.T) {
 
 	found := false
 	for name := range cfgs {
-		if name != "__main__" {
+		if name != domain.ModuleFunctionName {
 			found = true
 			break
 		}
@@ -1206,7 +1207,7 @@ func TestCFGBuilder_BuildAll_CallbackArgument(t *testing.T) {
 
 	found := false
 	for name := range cfgs {
-		if name != "__main__" {
+		if name != domain.ModuleFunctionName {
 			found = true
 			break
 		}
@@ -1233,7 +1234,7 @@ func TestCFGBuilder_BuildAll_Mixed(t *testing.T) {
 		t.Fatalf("BuildAll failed: %v", err)
 	}
 
-	// Should have __main__ + declared + arrow + assignment func + object method = 5
+	// Should have module-scope code + declared + arrow + assignment func + object method = 5
 	if len(cfgs) < 5 {
 		t.Errorf("BuildAll should detect all mixed function patterns, got %d CFGs (want >= 5)", len(cfgs))
 	}

--- a/internal/analyzer/complexity_test.go
+++ b/internal/analyzer/complexity_test.go
@@ -550,7 +550,7 @@ func TestComplexityAnalyzer_AnalyzeFile_MultipleFunctions(t *testing.T) {
 	if err != nil {
 		t.Fatalf("AnalyzeFile failed: %v", err)
 	}
-	// Should have results for __main__, add, subtract, multiply
+	// Should have results for module-scope, add, subtract, multiply
 	if len(results) < 4 {
 		t.Errorf("Should have at least 4 results, got %d", len(results))
 	}

--- a/service/complexity_service.go
+++ b/service/complexity_service.go
@@ -133,7 +133,7 @@ func (s *ComplexityServiceImpl) analyzeFile(ctx context.Context, filePath string
 
 	// Analyze complexity for each function
 	for funcName, cfg := range cfgs {
-		if funcName == "__main__" {
+		if funcName == domain.ModuleFunctionName {
 			continue // Skip main module
 		}
 

--- a/service/dead_code_aggregate.go
+++ b/service/dead_code_aggregate.go
@@ -174,7 +174,7 @@ func AnalyzeDeadCodeWithTask(ctx context.Context, req domain.DeadCodeRequest, ta
 		}
 
 		for funcName, result := range results {
-			if funcName == "__main__" {
+			if funcName == domain.ModuleFunctionName {
 				continue
 			}
 

--- a/service/dead_code_service.go
+++ b/service/dead_code_service.go
@@ -98,7 +98,7 @@ func (s *DeadCodeServiceImpl) analyzeFile(ctx context.Context, filePath string, 
 
 	for functionName, cfg := range cfgs {
 		// Skip module-level code
-		if functionName == "__main__" {
+		if functionName == domain.ModuleFunctionName {
 			continue
 		}
 

--- a/service/output_formatter.go
+++ b/service/output_formatter.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"math"
 	"sort"
 	"strconv"
 	"strings"
@@ -394,38 +395,33 @@ func (f *OutputFormatterImpl) writeAnalyzeJSON(
 	return WriteJSON(writer, response)
 }
 
-// calculateDuplicationPercentage calculates the percentage of duplicated code
+// calculateDuplicationPercentage calculates the code duplication metric based on
+// K-Core clone groups. K-Core groups represent true duplication clusters where each
+// fragment is similar to at least k other fragments (default k=2), which filters out
+// false positives from structural similarity.
 func calculateDuplicationPercentage(response *domain.CloneResponse) float64 {
-	if response == nil || response.Statistics == nil || response.Statistics.LinesAnalyzed == 0 {
+	if response == nil || response.Statistics == nil {
 		return 0.0
 	}
 
-	// Estimate duplicated lines from clone pairs
-	duplicatedLines := 0
-	seenLocations := make(map[string]bool)
-
-	for _, pair := range response.ClonePairs {
-		if pair.Clone1 != nil && pair.Clone1.Location != nil {
-			key := pair.Clone1.Location.String()
-			if !seenLocations[key] {
-				seenLocations[key] = true
-				duplicatedLines += pair.Clone1.LineCount
-			}
-		}
-		if pair.Clone2 != nil && pair.Clone2.Location != nil {
-			key := pair.Clone2.Location.String()
-			if !seenLocations[key] {
-				seenLocations[key] = true
-				duplicatedLines += pair.Clone2.LineCount
-			}
-		}
+	totalLines := response.Statistics.LinesAnalyzed
+	groupCount := response.Statistics.TotalCloneGroups
+	if totalLines == 0 || groupCount == 0 {
+		return 0.0
 	}
 
-	pct := float64(duplicatedLines) / float64(response.Statistics.LinesAnalyzed) * 100.0
-	if pct > 100.0 {
-		pct = 100.0
+	// Calculate group density: groups per 1000 lines of code
+	// This normalizes for project size
+	linesInThousands := float64(totalLines) / domain.GroupDensityLinesUnit
+	if linesInThousands < domain.GroupDensityMinLines {
+		linesInThousands = domain.GroupDensityMinLines
 	}
-	return pct
+	groupDensity := float64(groupCount) / linesInThousands
+
+	// Convert density to percentage for penalty calculation
+	// 0.5 groups/1000 lines = 10% duplication (max penalty)
+	// This makes the scoring stricter for duplicate code clusters
+	return math.Min(domain.DuplicationThresholdHigh, groupDensity*domain.GroupDensityCoefficient)
 }
 
 // writeComplexityText writes complexity response as plain text


### PR DESCRIPTION
## Summary

Second phase of the initial catch-up per SYNC.md (Scoring area). Compared the cumulative pyscn `origin/main` (`8650522`) diff against jscan's current state for `domain/analyze.go` / `domain/system_analysis.go` / `domain/complexity.go` and ported the missing scoring changes.

## Ported changes

| pyscn commit | Change | jscan files changed |
|---|---|---|
| `0886cfb`, `760bc87`, `68b6d2b` | Switch the duplication metric to K-Core clone-group density (groups per 1000 lines × 20, capped at 10%) with a 0–10% penalty scale | `domain/analyze.go`, `service/output_formatter.go` |
| `333c9ac`, `9c84a3d` | Soften CBO coupling calibration (medium weight 0.5→0.3, saturation at weighted ratio 0.40). Introduce the `CouplingMediumWeight` / `CouplingSaturationRatio` constants | `domain/analyze.go` |
| `3c9927c` | Use compliance directly as the ArchitectureScore (98% compliance = 98 points) | `domain/analyze.go` |
| `e6b9920` | Expose `WeightedViolations` to make ComplianceScore reproducible (ported for type alignment) | `domain/system_analysis.go` |
| `2cc013c` | Report module-scope code as `<module>` instead of `__main__` (introduce the `domain.ModuleFunctionName` constant and route all internal sentinel comparisons through it) | `domain/complexity.go`, `internal/analyzer/cfg_builder.go`, `service/complexity_service.go`, `service/dead_code_service.go`, `service/dead_code_aggregate.go` |

Mirroring pyscn's test updates (expected-value changes in analyze_test.go), added duplication / CBO / architecture score tests to `domain/analyze_test.go`, adapted to jscan's formulas.

## Skipped changes (recorded in SYNC.md pending changes)

- **LCOM cohesion scoring** (`54698b6`, `57fcc66`) — depends on the unported LCOM4 feature
- **Cognitive complexity / RawMetrics** (`8aa6d21`, `ce469ce`) — unported features
- **Mock/synthetic fixture detection** (`15bd414`) — pyscn-specific lint feature
- **Suggestions** (`1eaf9f6`) — depends on the unported `domain/suggestion.go`
- **Analyze config plumbing** (`222d190`, `779200a`, `13644b4`, `e79a414`, `d6fd3da`, `ca75d12`) — jscan's config-loader layer is structured differently, out of scope
- **Architecture style presets / warn rules / neutral prefixes / cohesion-responsibility validation** (`ad79460`, `1c9839d`, `61f0431`, `3708845`, `ddcf1c5`) — jscan does not implement architecture validation (types are unused scaffolding)
- **`AbstractClassCount`** (`f63540d`) — Python ABC detection; jscan computes abstractness its own way in `coupling_metrics.go` from TS interfaces/abstract classes
- **Django migration exclusion / Python default patterns** (`a33f1c7`) — Python-specific

Also documented jscan's intentional divergences in the SYNC.md file-mapping notes (`calculateComplexityPenalty` uses the high/medium count ratio; `calculateDeadCodePenalty` uses a per-file rate) so future syncs don't overwrite them.

## Verification

- `make test` passes
- Golden comparison on `test-repos/` (latest-version, junk, express):
  - **latest-version / junk**: the only difference is `architecture_score` 100→0, exactly as the ported formula dictates (jscan does not implement architecture validation, so compliance=0; pyscn produces the same value when arch is disabled). This is a JSON-only field, not shown in HTML/CLI output
  - **express**: `code_duplication_percentage` 56.4→10.0 (the group-density metric's cap; the penalty is the full 20 both before and after, so the health score stays at 74/C), and `architecture_score` 100→0 (same as above). The ±a-few jitter in `clone_pairs` reproduces across re-runs of the same binary — pre-existing nondeterminism, unrelated to this change (clone detection is untouched). Function lists, complexity, and dead-code aggregates match exactly

🤖 Generated with [Claude Code](https://claude.com/claude-code)