### PR TITLE
sync: catch up misc area with pyscn (initial catch-up 3/3)

### DIFF
--- a/SYNC.md
+++ b/SYNC.md
@@ -4,21 +4,9 @@ pyscn is the upstream (source of truth); changes to shared algorithms are ported
 The `/sync-pyscn` command reads this file to run a sync.
 
 - Upstream: https://github.com/ludo-technologies/pyscn (local clone: `../pyscn`)
-- **Sync baseline SHA**: `f0457d7e5826aab91f879fc88b9b01858c8f78f6` (2025-11-27, v1.4.1)
-  - The pyscn state that jscan's initial implementation was based on. All pyscn changes after this point are an **unported backlog**; the two tools are not in sync until the initial catch-up completes.
+- **Sync baseline SHA**: `fb3fe92d19e27c27994e0306ecee11fc46e5c937` (2026-06-12)
+  - The initial catch-up (clone detection / scoring / misc, 2026-06-11–12) compared jscan against pyscn's state up to this SHA. Exceptions that were deliberately not ported are listed under "Pending changes".
   - Update this value to pyscn's `origin/main` HEAD on each sync run.
-
-## Initial catch-up (incomplete)
-
-About 210 commits (71 of them classified as "sync") have accumulated on the synced files since the baseline.
-The initial catch-up must be done by **state comparison**, not by replaying individual commits:
-
-1. For each target file, compare pyscn's current `origin/main` content against jscan's current content and identify missing fixes and constant changes (use the commit log only to understand the intent of a change)
-2. Split the work into one PR per area, ordered by churn:
-   - **Clone detection** — **Done** (2026-06-11, compared against pyscn `73acc60`. PR: sync/catchup-clone) — covered `clone_detector.go`, `apted*.go`, the grouping strategies, `domain/clone.go`, `ast_features.go`, and newly ported `textual_similarity.go` / `syntactic_similarity.go`
-   - **Scoring** — **Done** (2026-06-11, compared against pyscn `8650522`. PR: sync/catchup-scoring) — covered `domain/analyze.go` (duplication 0–10% scale + group-density metric, CBO calibration, architecture score = compliance), `domain/system_analysis.go` (WeightedViolations), `domain/complexity.go` (`ModuleFunctionName`) and the `__main__` → `<module>` label migration
-   - **Misc** — `dependency_graph.go`, `reachability.go`, `lsh_index.go`, `coupling_metrics.go`, and other low-commit files
-3. Once all areas are done, delete this section and update the baseline SHA to the `origin/main` HEAD used during the catch-up
 
 ## Sync policy classification
 
@@ -95,7 +83,6 @@ Skipped during the clone detection catch-up (2026-06-11):
 - **Boilerplate cost model** (`NewPythonCostModelWithBoilerplateConfig`, `ReduceBoilerplateSimilarity` / `BoilerplateMultiplier`) — depends on Python framework patterns such as dataclass/Pydantic (`framework_patterns.go` is an unported feature)
 - **Multi-dimensional classifier and DFA** (`CloneClassifier`, `EnableMultiDimensionalAnalysis` / `EnableSemanticAnalysis` / `EnableDFA`) — depend on pyscn-specific unported features (semantic/structural similarity, DFA)
 - **Type-4 CFG gating** (`87babcc`, `9efebd4`) — changes inside `semantic_similarity.go` (unported). Port together with the semantic analysis
-- **LSH int IDs and `WithMaxCandidates`** (`LSHMaxCandidates`) — requires the `lsh_index.go` API change. Port during the "Misc" area catch-up
 - **`CloneConfigurationLoader.MergeConfig`** — config-loader-layer change. jscan's loader implementation differs, so out of scope
 - **star_medoid graph optimization** (`buildSimilarityGraph` / `mostSimilarMedoid`) — performance-only change, structurally different from jscan's StarMedoid implementation (iterative reassignment over domain.Clone). The `averageGroupSimilarity` change to count only existing pairs was ported
 - **pyscn's removal of the content-less `ExtractFragments`** — jscan tests still use it, so both variants were kept
@@ -111,6 +98,14 @@ Skipped during the scoring catch-up (2026-06-11):
 - **`AbstractClassCount`** (`f63540d`) — Python ABC detection; jscan computes abstractness its own way in `coupling_metrics.go` from TS interfaces/abstract classes
 - **Django migration exclusion / Python default patterns** (`a33f1c7`, `DefaultPythonModuleIncludePatterns`) — Python-specific
 
+Skipped during the misc catch-up (2026-06-12):
+
+- **APTED DP-matrix reuse + parallel pair verification** (`c324d2f`, `e912ca2`) — landed in pyscn after the clone-detection catch-up point (`73acc60`). Large performance rework of `apted.go` / `apted_tree.go` / `clone_detector.go` (worker pool, `newWorkerDetector` / `effectiveWorkers`, key-root cache invalidation, streamed LSH verification). Port as its own dedicated change; the LSH int-ID/`WithMaxCandidates` part was already ported in the misc catch-up
+- **complexity.go AST-based statement metrics + CognitiveComplexity** — the fix targets Python `match` decision-point double-counting (jscan counts JS branches its own way via logical/ternary operators), and `CalculateCognitiveComplexity` is an unported feature. Port together with `cognitive_complexity.go` if ever
+- **cfg.go `ModuleNode` / `complexitySourceNode`** — unnecessary in jscan: the module-level CFG already sets `FunctionNode` to the Program node, so location/nesting info is available
+- **`domain/defaults.go` constants refactor** (`DefaultAnalysisIncludePatterns`, `DefaultCBOLowThreshold` etc. in `domain/cbo.go` / `domain/dead_code.go`) — config-layer cosmetics with Python file patterns; jscan keeps its own defaults
+- **`DeadCodeResponse.Request` field** — analyze-config plumbing (already skipped as a category during the scoring catch-up)
+
 ## Sync history
 
 | Date | pyscn SHA | Summary |
@@ -118,3 +113,4 @@ Skipped during the scoring catch-up (2026-06-11):
 | 2026-06-11 | `f0457d7` | Set the baseline to the state jscan's initial implementation was based on (v1.4.1). The ~210 commits since then are the unported backlog targeted by the initial catch-up |
 | 2026-06-11 | `73acc60` | Initial catch-up: clone detection area done. APTED correctness fixes (ascending key roots, forest-distance subtreeCost, max(size) normalization), bounded large-tree approximation (same-shape distance, label/shape profiles), Jaccard pre-filter, Type-1 textual-match gate and Type-2 syntactic gate (ported textual/syntactic similarity), threshold recalibration (0.85/0.75/0.70/0.65), Type-3 disabled by default, overlapping-range pair rejection (isOverlappingLocation), strict-subset group member removal (group_dedup), complete_linkage rewritten as agglomerative clustering, MinLines/MinNodes 10/20, LSH auto-enable by estimated pair count, introduced `parser.OrderedChildren` |
 | 2026-06-11 | `8650522` | Initial catch-up: scoring area done. Duplication metric switched to K-Core group density (groups per 1000 lines × 20, capped at 10%) with 0–10% penalty scale (`0886cfb`, `760bc87`), CBO coupling calibration softened (medium weight 0.3, saturation 0.40, `333c9ac`, `9c84a3d`), architecture score now uses compliance directly (`3c9927c`), `WeightedViolations` exposed (`e6b9920`), module-scope label `__main__` → `<module>` via `domain.ModuleFunctionName` (`2cc013c`) |
+| 2026-06-12 | `fb3fe92` | Initial catch-up: misc area done (catch-up complete; baseline moved to `fb3fe92`). LSH index switched to int fragment IDs with `WithMaxCandidates` cap (default 1024) and sorted deterministic candidates, reachability `allSuccessorsReturn` memoized (removed `copyVisited`), lazy-import cycle exclusion ported as dynamic-`import()` edge skipping in circular detection (#460), coupling zone classification aligned (Zone of Pain requires D≥0.5/Ca≥2/I≤0.3/A≤0.3, main sequence D≤0.2, instability defaults 0.3/0.7), dead-code findings merged per contiguous same-reason region with EndLine sort tiebreak, bare-`;` (empty statement) dead-code noise filtered (`empty_statement` now maps to `NodeEmptyStatement`), domain error codes TIMEOUT/CANCELLED/NOT_IMPLEMENTED/INTERNAL added |

--- a/domain/dependency_graph.go
+++ b/domain/dependency_graph.go
@@ -200,8 +200,8 @@ func DefaultDependencyGraphRequest() *DependencyGraphRequest {
 		IncludeExternal:          BoolPtr(false),
 		IncludeTypeImports:       BoolPtr(true),
 		DetectCycles:             BoolPtr(true),
-		InstabilityHighThreshold: 0.8,
-		InstabilityLowThreshold:  0.2,
+		InstabilityHighThreshold: 0.7,
+		InstabilityLowThreshold:  0.3,
 		DistanceThreshold:        0.3,
 	}
 }

--- a/domain/errors.go
+++ b/domain/errors.go
@@ -31,6 +31,10 @@ const (
 	ErrCodeConfigError       = "CONFIG_ERROR"
 	ErrCodeOutputError       = "OUTPUT_ERROR"
 	ErrCodeUnsupportedFormat = "UNSUPPORTED_FORMAT"
+	ErrCodeTimeout           = "TIMEOUT"
+	ErrCodeCancelled         = "CANCELLED"
+	ErrCodeNotImplemented    = "NOT_IMPLEMENTED"
+	ErrCodeInternal          = "INTERNAL"
 )
 
 // NewDomainError creates a new domain error
@@ -80,4 +84,24 @@ func NewUnsupportedFormatError(format string) error {
 // NewValidationError creates a validation error
 func NewValidationError(message string) error {
 	return NewDomainError(ErrCodeInvalidInput, message, nil)
+}
+
+// NewTimeoutError creates a timeout error
+func NewTimeoutError(message string, cause error) error {
+	return NewDomainError(ErrCodeTimeout, message, cause)
+}
+
+// NewCancelledError creates a cancellation error
+func NewCancelledError(message string, cause error) error {
+	return NewDomainError(ErrCodeCancelled, message, cause)
+}
+
+// NewNotImplementedError creates a not implemented error
+func NewNotImplementedError(feature string) error {
+	return NewDomainError(ErrCodeNotImplemented, fmt.Sprintf("not implemented: %s", feature), nil)
+}
+
+// NewInternalError creates an internal error
+func NewInternalError(message string, cause error) error {
+	return NewDomainError(ErrCodeInternal, message, cause)
 }

--- a/internal/analyzer/circular_detector.go
+++ b/internal/analyzer/circular_detector.go
@@ -24,6 +24,15 @@ func NewCircularDependencyDetector() *CircularDependencyDetector {
 	return &CircularDependencyDetector{}
 }
 
+// isLoadTimeEdge reports whether an edge participates in module loading.
+// Dynamic import() edges are evaluated only when the call executes, so they
+// cannot form a load-time circular import and are excluded from cycle
+// detection. A pair connected by both a static and a dynamic import is still
+// a load-time dependency via its static edge. See pyscn issue #460.
+func isLoadTimeEdge(edge *domain.DependencyEdge) bool {
+	return edge != nil && edge.EdgeType != domain.EdgeTypeDynamic
+}
+
 // DetectCycles finds all cycles in the dependency graph using Tarjan's SCC algorithm
 func (d *CircularDependencyDetector) DetectCycles(graph *domain.DependencyGraph) *domain.CircularDependencyAnalysis {
 	if graph == nil || graph.NodeCount() == 0 {
@@ -113,6 +122,11 @@ func (d *CircularDependencyDetector) strongconnect(v string, graph *domain.Depen
 	// Consider successors of v
 	edges := graph.GetOutgoingEdges(v)
 	for _, edge := range edges {
+		// Lazy (dynamic import) edges do not run at module load time, so
+		// they cannot form a load-time cycle. Skip them. See issue #460.
+		if !isLoadTimeEdge(edge) {
+			continue
+		}
 		w := edge.To
 		// Skip external/unresolved nodes that aren't in the graph
 		if graph.GetNode(w) == nil {
@@ -160,6 +174,9 @@ func (d *CircularDependencyDetector) buildCycleInfo(scc []string, graph *domain.
 	for _, from := range scc {
 		edges := graph.GetOutgoingEdges(from)
 		for _, edge := range edges {
+			if !isLoadTimeEdge(edge) {
+				continue // lazy edges are not load-time dependencies (#460)
+			}
 			if sccSet[edge.To] {
 				paths = append(paths, domain.DependencyPath{
 					From:   from,
@@ -268,6 +285,9 @@ func (d *CircularDependencyDetector) findBestEdgeToBreak(cycle domain.CircularDe
 	for _, module := range cycle.Modules {
 		edges := graph.GetOutgoingEdges(module)
 		for _, edge := range edges {
+			if !isLoadTimeEdge(edge) {
+				continue // breaking a lazy edge would not break the load-time cycle
+			}
 			if sccSet[edge.To] && edge.Weight < minWeight {
 				minWeight = edge.Weight
 				bestEdge = edge
@@ -321,6 +341,9 @@ func (d *CircularDependencyDetector) FindCyclePath(from, to string, graph *domai
 
 		edges := graph.GetOutgoingEdges(current)
 		for _, edge := range edges {
+			if !isLoadTimeEdge(edge) {
+				continue // lazy edges are not load-time dependencies (#460)
+			}
 			if dfs(edge.To) {
 				return true
 			}

--- a/internal/analyzer/circular_detector_test.go
+++ b/internal/analyzer/circular_detector_test.go
@@ -331,3 +331,45 @@ func TestGenerateCycleDescription(t *testing.T) {
 		t.Error("Expected description to mention 3 modules")
 	}
 }
+
+func TestDetectCyclesSkipsDynamicEdges(t *testing.T) {
+	// A -> B (static), B -> A (dynamic import only): a dynamic import is
+	// evaluated at call time, not module load time, so this is not a
+	// load-time cycle. See pyscn issue #460.
+	graph := domain.NewDependencyGraph()
+	graph.AddNode(&domain.ModuleNode{ID: "a"})
+	graph.AddNode(&domain.ModuleNode{ID: "b"})
+	graph.AddEdge(&domain.DependencyEdge{From: "a", To: "b", EdgeType: domain.EdgeTypeImport, Weight: 1})
+	graph.AddEdge(&domain.DependencyEdge{From: "b", To: "a", EdgeType: domain.EdgeTypeDynamic, Weight: 1})
+
+	detector := NewCircularDependencyDetector()
+	result := detector.DetectCycles(graph)
+
+	if result.HasCircularDependencies {
+		t.Error("Expected no circular dependencies when back edge is dynamic-only")
+	}
+	if result.TotalCycles != 0 {
+		t.Errorf("Expected 0 cycles, got %d", result.TotalCycles)
+	}
+}
+
+func TestDetectCyclesKeepsCycleWithStaticAndDynamicEdges(t *testing.T) {
+	// A -> B (static), B -> A (static AND dynamic): the static back edge
+	// still forms a load-time cycle; the extra dynamic edge must not hide it.
+	graph := domain.NewDependencyGraph()
+	graph.AddNode(&domain.ModuleNode{ID: "a"})
+	graph.AddNode(&domain.ModuleNode{ID: "b"})
+	graph.AddEdge(&domain.DependencyEdge{From: "a", To: "b", EdgeType: domain.EdgeTypeImport, Weight: 1})
+	graph.AddEdge(&domain.DependencyEdge{From: "b", To: "a", EdgeType: domain.EdgeTypeDynamic, Weight: 1})
+	graph.AddEdge(&domain.DependencyEdge{From: "b", To: "a", EdgeType: domain.EdgeTypeImport, Weight: 1})
+
+	detector := NewCircularDependencyDetector()
+	result := detector.DetectCycles(graph)
+
+	if !result.HasCircularDependencies {
+		t.Error("Expected circular dependencies to be detected via the static back edge")
+	}
+	if result.TotalCycles != 1 {
+		t.Errorf("Expected 1 cycle, got %d", result.TotalCycles)
+	}
+}

--- a/internal/analyzer/clone_detector.go
+++ b/internal/analyzer/clone_detector.go
@@ -112,6 +112,7 @@ type CloneDetectorConfig struct {
 	LSHBands               int     // Number of LSH bands (default: 32)
 	LSHRows                int     // Rows per band (default: 4)
 	LSHMinHashCount        int     // Number of MinHash functions (default: 128)
+	LSHMaxCandidates       int     // Maximum candidates returned per LSH query
 }
 
 // DefaultCloneDetectorConfig returns default configuration
@@ -145,6 +146,7 @@ func DefaultCloneDetectorConfig() *CloneDetectorConfig {
 		LSHBands:               32,
 		LSHRows:                4,
 		LSHMinHashCount:        128,
+		LSHMaxCandidates:       defaultLSHMaxCandidates,
 	}
 }
 
@@ -496,23 +498,18 @@ func (cd *CloneDetector) DetectClonesWithLSH(ctx context.Context, fragments []*C
 	hasher := NewMinHasher(cd.cloneDetectorConfig.LSHMinHashCount)
 
 	type fragRec struct {
-		id  string
 		idx int
 		sig *MinHashSignature
 	}
 	records := make([]fragRec, 0, len(cd.fragments))
 	sigByIndex := make(map[int]*MinHashSignature, len(cd.fragments))
-	idToIndex := make(map[string]int, len(cd.fragments))
 	for i, f := range cd.fragments {
 		if f == nil || f.TreeNode == nil {
 			continue
 		}
-		// Build a stable ID for the fragment
-		id := fmt.Sprintf("%s:%d-%d", f.Location.FilePath, f.Location.StartLine, f.Location.EndLine)
 		sig := hasher.ComputeSignature(f.Features)
-		records = append(records, fragRec{id: id, idx: i, sig: sig})
+		records = append(records, fragRec{idx: i, sig: sig})
 		sigByIndex[i] = sig
-		idToIndex[id] = i
 	}
 
 	// Edge case: if signatures cannot be built, fallback
@@ -521,9 +518,10 @@ func (cd *CloneDetector) DetectClonesWithLSH(ctx context.Context, fragments []*C
 	}
 
 	// Stage 2: LSH indexing
-	lsh := NewLSHIndex(cd.cloneDetectorConfig.LSHBands, cd.cloneDetectorConfig.LSHRows)
+	lsh := NewLSHIndex(cd.cloneDetectorConfig.LSHBands, cd.cloneDetectorConfig.LSHRows).
+		WithMaxCandidates(cd.cloneDetectorConfig.LSHMaxCandidates)
 	for _, r := range records {
-		_ = lsh.AddFragment(r.id, r.sig)
+		_ = lsh.AddFragment(r.idx, r.sig)
 	}
 	_ = lsh.BuildIndex()
 
@@ -543,8 +541,7 @@ func (cd *CloneDetector) DetectClonesWithLSH(ctx context.Context, fragments []*C
 			break
 		}
 		cands := lsh.FindCandidates(r.sig)
-		for _, cid := range cands {
-			j := idToIndex[cid]
+		for _, j := range cands {
 			i := r.idx
 			if j == i || j < 0 || i < 0 {
 				continue

--- a/internal/analyzer/coupling_metrics.go
+++ b/internal/analyzer/coupling_metrics.go
@@ -7,12 +7,19 @@ import (
 	"github.com/ludo-technologies/jscan/domain"
 )
 
+const (
+	mainSequenceMaxDistance = 0.2
+	zoneMinDistance         = 0.5
+	lowAbstractness         = 0.3
+	highAbstractness        = 0.7
+)
+
 // CouplingMetricsConfig configures the CouplingMetricsCalculator
 type CouplingMetricsConfig struct {
-	// InstabilityHighThreshold defines the threshold for high instability (default: 0.8)
+	// InstabilityHighThreshold defines the threshold for high instability (default: 0.7)
 	InstabilityHighThreshold float64
 
-	// InstabilityLowThreshold defines the threshold for low instability (default: 0.2)
+	// InstabilityLowThreshold defines the threshold for low instability (default: 0.3)
 	InstabilityLowThreshold float64
 
 	// DistanceThreshold defines the threshold for main sequence deviation (default: 0.3)
@@ -28,8 +35,8 @@ type CouplingMetricsConfig struct {
 // DefaultCouplingMetricsConfig returns a config with sensible defaults
 func DefaultCouplingMetricsConfig() *CouplingMetricsConfig {
 	return &CouplingMetricsConfig{
-		InstabilityHighThreshold: 0.8,
-		InstabilityLowThreshold:  0.2,
+		InstabilityHighThreshold: 0.7,
+		InstabilityLowThreshold:  0.3,
 		DistanceThreshold:        0.3,
 		CouplingHighThreshold:    10,
 		CouplingMediumThreshold:  5,
@@ -143,13 +150,13 @@ func (c *CouplingMetricsCalculator) CalculateCouplingAnalysis(graph *domain.Depe
 		}
 
 		// Classify by zone
-		zone := c.classifyStabilityZone(m.Instability, m.Abstractness, m.Distance)
+		zone := c.classifyStabilityZone(m)
 		switch zone {
 		case "zone_of_pain":
 			zoneOfPain = append(zoneOfPain, nodeID)
 		case "zone_of_uselessness":
 			zoneOfUselessness = append(zoneOfUselessness, nodeID)
-		default:
+		case "main_sequence":
 			mainSequence = append(mainSequence, nodeID)
 		}
 	}
@@ -231,26 +238,33 @@ func (c *CouplingMetricsCalculator) calculateDistance(instability, abstractness 
 	return math.Abs(abstractness + instability - 1.0)
 }
 
-// classifyStabilityZone classifies a module into a stability zone
-func (c *CouplingMetricsCalculator) classifyStabilityZone(instability, abstractness, distance float64) string {
-	// Main Sequence: D < threshold
-	if distance < c.config.DistanceThreshold {
-		return "main_sequence"
-	}
-
-	// Zone of Pain: Low I (stable) + Low A (concrete)
-	// Hard to change, lots depend on it, but it's concrete
-	if instability < 0.5 && abstractness < 0.5 {
+// classifyStabilityZone classifies a module into a stability zone.
+// Modules between the main sequence band and the zones belong to no zone
+// and return an empty string.
+func (c *CouplingMetricsCalculator) classifyStabilityZone(m *domain.ModuleDependencyMetrics) string {
+	// Zone of Pain: stable concrete modules far from the main sequence that
+	// other modules actually depend on. Hard to change, lots depend on it.
+	if m.Distance >= zoneMinDistance &&
+		m.AfferentCoupling >= 2 &&
+		m.Instability <= c.config.InstabilityLowThreshold &&
+		m.Abstractness <= lowAbstractness {
 		return "zone_of_pain"
 	}
 
-	// Zone of Uselessness: High I (unstable) + High A (abstract)
-	// Abstract but nothing uses it
-	if instability > 0.5 && abstractness > 0.5 {
+	// Zone of Uselessness: unstable abstract modules far from the main
+	// sequence. Abstract but nothing uses it.
+	if m.Distance >= zoneMinDistance &&
+		m.Instability >= c.config.InstabilityHighThreshold &&
+		m.Abstractness >= highAbstractness {
 		return "zone_of_uselessness"
 	}
 
-	return "main_sequence"
+	// Main Sequence: modules close to A + I = 1
+	if m.Distance <= mainSequenceMaxDistance {
+		return "main_sequence"
+	}
+
+	return ""
 }
 
 // assessRiskLevel assesses the risk level based on coupling and distance

--- a/internal/analyzer/coupling_metrics_test.go
+++ b/internal/analyzer/coupling_metrics_test.go
@@ -10,11 +10,11 @@ import (
 func TestDefaultCouplingMetricsConfig(t *testing.T) {
 	config := DefaultCouplingMetricsConfig()
 
-	if config.InstabilityHighThreshold != 0.8 {
-		t.Errorf("Expected InstabilityHighThreshold 0.8, got %f", config.InstabilityHighThreshold)
+	if config.InstabilityHighThreshold != 0.7 {
+		t.Errorf("Expected InstabilityHighThreshold 0.7, got %f", config.InstabilityHighThreshold)
 	}
-	if config.InstabilityLowThreshold != 0.2 {
-		t.Errorf("Expected InstabilityLowThreshold 0.2, got %f", config.InstabilityLowThreshold)
+	if config.InstabilityLowThreshold != 0.3 {
+		t.Errorf("Expected InstabilityLowThreshold 0.3, got %f", config.InstabilityLowThreshold)
 	}
 	if config.DistanceThreshold != 0.3 {
 		t.Errorf("Expected DistanceThreshold 0.3, got %f", config.DistanceThreshold)
@@ -132,21 +132,30 @@ func TestClassifyStabilityZone(t *testing.T) {
 		instability  float64
 		abstractness float64
 		distance     float64
+		afferent     int
 		expected     string
 	}{
-		{0.5, 0.5, 0.0, "main_sequence"},       // On main sequence
-		{0.5, 0.5, 0.2, "main_sequence"},       // Near main sequence
-		{0.2, 0.2, 0.6, "zone_of_pain"},        // Stable + concrete
-		{0.1, 0.1, 0.8, "zone_of_pain"},        // Very stable + concrete
-		{0.8, 0.8, 0.6, "zone_of_uselessness"}, // Unstable + abstract
-		{0.9, 0.9, 0.8, "zone_of_uselessness"}, // Very unstable + abstract
+		{0.5, 0.5, 0.0, 0, "main_sequence"},       // On main sequence
+		{0.5, 0.5, 0.2, 0, "main_sequence"},       // Near main sequence
+		{0.2, 0.2, 0.6, 2, "zone_of_pain"},        // Stable + concrete, depended on
+		{0.1, 0.1, 0.8, 5, "zone_of_pain"},        // Very stable + concrete, depended on
+		{0.2, 0.2, 0.6, 1, ""},                    // Stable + concrete but nothing depends on it
+		{0.8, 0.8, 0.6, 0, "zone_of_uselessness"}, // Unstable + abstract
+		{0.9, 0.9, 0.8, 0, "zone_of_uselessness"}, // Very unstable + abstract
+		{0.5, 0.5, 0.35, 0, ""},                   // Off the main sequence but in no zone
 	}
 
 	for _, tc := range testCases {
-		result := calc.classifyStabilityZone(tc.instability, tc.abstractness, tc.distance)
+		m := &domain.ModuleDependencyMetrics{
+			Instability:      tc.instability,
+			Abstractness:     tc.abstractness,
+			Distance:         tc.distance,
+			AfferentCoupling: tc.afferent,
+		}
+		result := calc.classifyStabilityZone(m)
 		if result != tc.expected {
-			t.Errorf("Zone(I=%f, A=%f, D=%f) = %s, expected %s",
-				tc.instability, tc.abstractness, tc.distance, result, tc.expected)
+			t.Errorf("Zone(I=%f, A=%f, D=%f, Ca=%d) = %q, expected %q",
+				tc.instability, tc.abstractness, tc.distance, tc.afferent, result, tc.expected)
 		}
 	}
 }

--- a/internal/analyzer/dead_code.go
+++ b/internal/analyzer/dead_code.go
@@ -153,8 +153,18 @@ func (dcd *DeadCodeDetector) Detect() *DeadCodeResult {
 
 	// Sort findings by line number for consistent output
 	sort.Slice(result.Findings, func(i, j int) bool {
-		return result.Findings[i].StartLine < result.Findings[j].StartLine
+		if result.Findings[i].StartLine != result.Findings[j].StartLine {
+			return result.Findings[i].StartLine < result.Findings[j].StartLine
+		}
+		return result.Findings[i].EndLine < result.Findings[j].EndLine
 	})
+
+	// Merge overlapping/contiguous findings that share a reason. A compound
+	// statement (e.g. `if`) spans its body, so the body's own block produces a
+	// finding whose line range is nested inside the `if` finding's range. Left
+	// as-is, the same source line is reported—and tallied—more than once. Merging
+	// collapses each contiguous dead region into a single non-overlapping finding.
+	result.Findings = mergeContiguousFindings(result.Findings)
 
 	result.AnalysisTime = time.Since(startTime)
 	return result
@@ -163,6 +173,15 @@ func (dcd *DeadCodeDetector) Detect() *DeadCodeResult {
 // analyzeDeadBlock analyzes a dead block to determine the reason and create findings
 func (dcd *DeadCodeDetector) analyzeDeadBlock(block *BasicBlock) []*DeadCodeFinding {
 	var findings []*DeadCodeFinding
+
+	// Skip blocks whose only "statements" are empty separators (a bare `;`).
+	// A trailing semicolon (`return y;;`) parses as the terminating statement
+	// followed by an empty statement. That empty statement is technically
+	// unreachable, but reporting it is noise — there's nothing for the user to
+	// act on beyond a stylistic extra semicolon.
+	if isOnlyEmptyStatements(block) {
+		return findings
+	}
 
 	// Determine the reason for unreachability
 	reason, severity := dcd.determineDeadCodeReason(block)
@@ -290,6 +309,85 @@ func DetectAll(cfgs map[string]*CFG, filePath string) map[string]*DeadCodeResult
 	}
 
 	return results
+}
+
+// mergeContiguousFindings collapses findings whose line ranges overlap or are
+// directly adjacent (no reachable line between them) and that share the same
+// reason into a single finding. Findings must be pre-sorted by StartLine (then
+// EndLine). This removes the overlapping/duplicate ranges that arise because a
+// compound statement's finding spans its body while the body's block emits its
+// own nested finding.
+func mergeContiguousFindings(findings []*DeadCodeFinding) []*DeadCodeFinding {
+	if len(findings) <= 1 {
+		return findings
+	}
+
+	severityRank := map[SeverityLevel]int{
+		SeverityLevelInfo:     1,
+		SeverityLevelWarning:  2,
+		SeverityLevelCritical: 3,
+	}
+
+	merged := make([]*DeadCodeFinding, 0, len(findings))
+	current := findings[0]
+
+	for _, next := range findings[1:] {
+		// Contiguous if the next finding starts at or before the line right after
+		// the current region's end (overlapping or back-to-back lines).
+		contiguous := next.StartLine <= current.EndLine+1
+		if contiguous && next.Reason == current.Reason {
+			if next.EndLine > current.EndLine {
+				current.EndLine = next.EndLine
+			}
+			current.Code = mergeCodeLines(current.Code, next.Code)
+			if severityRank[next.Severity] > severityRank[current.Severity] {
+				current.Severity = next.Severity
+				current.Description = next.Description
+			}
+			continue
+		}
+		merged = append(merged, current)
+		current = next
+	}
+	merged = append(merged, current)
+
+	return merged
+}
+
+// mergeCodeLines appends the lines of b to a, skipping a leading line of b that
+// duplicates the trailing line of a. This keeps the merged snippet readable when
+// a nested-body block repeats the line already shown by its enclosing statement.
+func mergeCodeLines(a, b string) string {
+	if a == "" {
+		return b
+	}
+	if b == "" {
+		return a
+	}
+	aLines := strings.Split(a, "\n")
+	bLines := strings.Split(b, "\n")
+	if len(aLines) > 0 && len(bLines) > 0 && aLines[len(aLines)-1] == bLines[0] {
+		bLines = bLines[1:]
+	}
+	if len(bLines) == 0 {
+		return a
+	}
+	return a + "\n" + strings.Join(bLines, "\n")
+}
+
+// isOnlyEmptyStatements reports whether every statement in the block is an
+// empty separator node (a bare `;`). Such blocks are unreachable but carry no
+// actionable signal, so they should not produce dead-code findings.
+func isOnlyEmptyStatements(block *BasicBlock) bool {
+	if block == nil || len(block.Statements) == 0 {
+		return false
+	}
+	for _, stmt := range block.Statements {
+		if stmt == nil || stmt.Type != parser.NodeEmptyStatement {
+			return false
+		}
+	}
+	return true
 }
 
 // HasFindings returns true if there are any dead code findings

--- a/internal/analyzer/dead_code_test.go
+++ b/internal/analyzer/dead_code_test.go
@@ -2,6 +2,8 @@ package analyzer
 
 import (
 	"testing"
+
+	"github.com/ludo-technologies/jscan/internal/parser"
 )
 
 func TestSeverityLevelConstants(t *testing.T) {
@@ -479,5 +481,191 @@ func TestDeadCodeDetector_Detect_NestedControlFlow(t *testing.T) {
 
 	if result == nil {
 		t.Fatal("Result should not be nil")
+	}
+}
+
+// TestDeadCodeSkipsTrailingSemicolonNoise ensures the dead-code detector does
+// not emit findings for the empty statement produced by a trailing `;` after a
+// terminating statement (return/throw).
+func TestDeadCodeSkipsTrailingSemicolonNoise(t *testing.T) {
+	code := `
+		function f(x) {
+			if (x === null) {
+				throw new Error("nope");;
+			}
+			return x;
+		}
+
+		function g(y) {
+			return y;;
+		}
+	`
+	ast := parseJS(t, code)
+
+	for _, fnName := range []string{"f", "g"} {
+		funcNode := findFunction(ast, fnName)
+		if funcNode == nil {
+			t.Fatalf("expected function node for %s", fnName)
+		}
+
+		builder := NewCFGBuilder()
+		cfg, err := builder.Build(funcNode)
+		if err != nil {
+			t.Fatalf("Build failed for %s: %v", fnName, err)
+		}
+
+		result := NewDeadCodeDetector(cfg).Detect()
+		for _, finding := range result.Findings {
+			if finding.Code == string(parser.NodeEmptyStatement) {
+				t.Errorf("function %s: dead-code finding for a bare ';' (trailing-semicolon empty statement) should be filtered out; got %+v",
+					fnName, finding)
+			}
+		}
+	}
+}
+
+func TestDeadCodeNoOverlappingFindings(t *testing.T) {
+	// A compound statement (if) spans its body, so the body's own block used to
+	// emit a finding whose range was nested inside the if's finding range,
+	// double-counting the same source line. The whole region after `throw` is
+	// one contiguous dead region and should produce non-overlapping findings.
+	code := `
+		function doFlip(showWidgets) {
+			throw new Error("not implemented");
+			let tooltip = null;
+			if (showWidgets) {
+				renderWidgets();
+			}
+			if (tooltip) {
+				renderNotifications();
+			}
+		}
+	`
+	ast := parseJS(t, code)
+	funcNode := findFunction(ast, "doFlip")
+	if funcNode == nil {
+		t.Fatal("expected function node for doFlip")
+	}
+
+	builder := NewCFGBuilder()
+	cfg, err := builder.Build(funcNode)
+	if err != nil {
+		t.Fatalf("Build failed: %v", err)
+	}
+
+	result := NewDeadCodeDetector(cfg).Detect()
+	if len(result.Findings) == 0 {
+		t.Fatal("expected dead-code findings after throw")
+	}
+
+	// Findings must not have overlapping line ranges: each finding's start line
+	// must be strictly after the previous finding's end line.
+	for i := 1; i < len(result.Findings); i++ {
+		prev := result.Findings[i-1]
+		cur := result.Findings[i]
+		if cur.StartLine <= prev.EndLine {
+			t.Errorf("findings overlap: %+v then %+v", prev, cur)
+		}
+	}
+}
+
+func TestMergeContiguousFindings(t *testing.T) {
+	mk := func(start, end int, reason DeadCodeReason, sev SeverityLevel) *DeadCodeFinding {
+		return &DeadCodeFinding{StartLine: start, EndLine: end, Reason: reason, Severity: sev, Code: "x"}
+	}
+
+	t.Run("merges overlapping same-reason findings", func(t *testing.T) {
+		in := []*DeadCodeFinding{
+			mk(4, 6, ReasonUnreachableAfterThrow, SeverityLevelWarning),
+			mk(6, 6, ReasonUnreachableAfterThrow, SeverityLevelCritical),
+		}
+		out := mergeContiguousFindings(in)
+		if len(out) != 1 {
+			t.Fatalf("expected 1 finding, got %d", len(out))
+		}
+		if out[0].StartLine != 4 || out[0].EndLine != 6 {
+			t.Errorf("expected merged range 4-6, got %d-%d", out[0].StartLine, out[0].EndLine)
+		}
+		if out[0].Severity != SeverityLevelCritical {
+			t.Errorf("expected highest severity to be kept, got %s", out[0].Severity)
+		}
+	})
+
+	t.Run("merges adjacent same-reason findings", func(t *testing.T) {
+		in := []*DeadCodeFinding{
+			mk(4, 6, ReasonUnreachableAfterThrow, SeverityLevelCritical),
+			mk(7, 8, ReasonUnreachableAfterThrow, SeverityLevelCritical),
+		}
+		out := mergeContiguousFindings(in)
+		if len(out) != 1 {
+			t.Fatalf("expected 1 finding, got %d", len(out))
+		}
+		if out[0].EndLine != 8 {
+			t.Errorf("expected merged end line 8, got %d", out[0].EndLine)
+		}
+	})
+
+	t.Run("does not merge across a gap", func(t *testing.T) {
+		in := []*DeadCodeFinding{
+			mk(4, 4, ReasonUnreachableAfterThrow, SeverityLevelCritical),
+			mk(6, 6, ReasonUnreachableAfterThrow, SeverityLevelCritical),
+		}
+		out := mergeContiguousFindings(in)
+		if len(out) != 2 {
+			t.Errorf("expected 2 findings, got %d", len(out))
+		}
+	})
+
+	t.Run("does not merge different reasons", func(t *testing.T) {
+		in := []*DeadCodeFinding{
+			mk(4, 6, ReasonUnreachableAfterThrow, SeverityLevelCritical),
+			mk(6, 6, ReasonUnreachableBranch, SeverityLevelWarning),
+		}
+		out := mergeContiguousFindings(in)
+		if len(out) != 2 {
+			t.Errorf("expected 2 findings, got %d", len(out))
+		}
+	})
+}
+
+func TestMergeCodeLines(t *testing.T) {
+	cases := []struct {
+		a, b, expected string
+	}{
+		{"", "b", "b"},
+		{"a", "", "a"},
+		{"a", "b", "a\nb"},
+		// Duplicate boundary line (nested body repeats enclosing line) is collapsed.
+		{"if\nCall", "Call", "if\nCall"},
+	}
+	for _, tc := range cases {
+		if got := mergeCodeLines(tc.a, tc.b); got != tc.expected {
+			t.Errorf("mergeCodeLines(%q, %q) = %q, expected %q", tc.a, tc.b, got, tc.expected)
+		}
+	}
+}
+
+func TestIsOnlyEmptyStatements(t *testing.T) {
+	if isOnlyEmptyStatements(nil) {
+		t.Error("nil block should not be empty-statements-only")
+	}
+	if isOnlyEmptyStatements(&BasicBlock{}) {
+		t.Error("empty block should not be empty-statements-only")
+	}
+
+	semi := &parser.Node{Type: parser.NodeEmptyStatement}
+	ret := &parser.Node{Type: parser.NodeReturnStatement}
+
+	if !isOnlyEmptyStatements(&BasicBlock{Statements: []*parser.Node{semi}}) {
+		t.Error("block with only a separator should be empty-statements-only")
+	}
+	if !isOnlyEmptyStatements(&BasicBlock{Statements: []*parser.Node{semi, semi}}) {
+		t.Error("block with multiple separators should be empty-statements-only")
+	}
+	if isOnlyEmptyStatements(&BasicBlock{Statements: []*parser.Node{ret}}) {
+		t.Error("block with a real statement should not be empty-statements-only")
+	}
+	if isOnlyEmptyStatements(&BasicBlock{Statements: []*parser.Node{semi, ret}}) {
+		t.Error("block mixing separators and a real statement should not be empty-statements-only")
 	}
 }

--- a/internal/analyzer/lsh_index.go
+++ b/internal/analyzer/lsh_index.go
@@ -4,14 +4,18 @@ import (
 	"encoding/binary"
 	"fmt"
 	"hash/fnv"
+	"sort"
 )
+
+const defaultLSHMaxCandidates = 1024
 
 // LSHIndex implements MinHash LSH with banding
 type LSHIndex struct {
-	bands      int
-	rows       int
-	buckets    map[string][]string // band_hash -> fragment_ids
-	signatures map[string]*MinHashSignature
+	bands         int
+	rows          int
+	maxCandidates int
+	buckets       map[string][]int // band_hash -> fragment indexes
+	signatures    map[int]*MinHashSignature
 }
 
 // NewLSHIndex creates an index with banding parameters
@@ -23,20 +27,29 @@ func NewLSHIndex(bands, rows int) *LSHIndex {
 		rows = 4
 	}
 	return &LSHIndex{
-		bands:      bands,
-		rows:       rows,
-		buckets:    make(map[string][]string),
-		signatures: make(map[string]*MinHashSignature),
+		bands:         bands,
+		rows:          rows,
+		maxCandidates: defaultLSHMaxCandidates,
+		buckets:       make(map[string][]int),
+		signatures:    make(map[int]*MinHashSignature),
 	}
 }
 
-// AddFragment inserts a fragment signature into the index
-func (idx *LSHIndex) AddFragment(id string, signature *MinHashSignature) error {
-	if signature == nil || len(signature.signatures) == 0 {
-		return fmt.Errorf("empty signature for id %s", id)
+// WithMaxCandidates caps the number of candidates returned for a query.
+func (idx *LSHIndex) WithMaxCandidates(maxCandidates int) *LSHIndex {
+	if maxCandidates > 0 {
+		idx.maxCandidates = maxCandidates
 	}
-	if id == "" {
-		return fmt.Errorf("empty fragment id")
+	return idx
+}
+
+// AddFragment inserts a fragment signature into the index
+func (idx *LSHIndex) AddFragment(id int, signature *MinHashSignature) error {
+	if signature == nil || len(signature.signatures) == 0 {
+		return fmt.Errorf("empty signature for id %d", id)
+	}
+	if id < 0 {
+		return fmt.Errorf("negative fragment id: %d", id)
 	}
 	idx.signatures[id] = signature
 	idx.addToBuckets(id, signature)
@@ -47,28 +60,35 @@ func (idx *LSHIndex) AddFragment(id string, signature *MinHashSignature) error {
 func (idx *LSHIndex) BuildIndex() error { return nil }
 
 // FindCandidates retrieves candidate fragment IDs that share at least one band bucket
-func (idx *LSHIndex) FindCandidates(signature *MinHashSignature) []string {
+func (idx *LSHIndex) FindCandidates(signature *MinHashSignature) []int {
 	if signature == nil || len(signature.signatures) == 0 {
-		return []string{}
+		return []int{}
 	}
-	ids := make(map[string]struct{})
+	ids := make(map[int]struct{})
 	bands := idx.computeBandKeys(signature)
 	for _, key := range bands {
 		if bucket, ok := idx.buckets[key]; ok {
 			for _, id := range bucket {
+				if idx.maxCandidates > 0 && len(ids) >= idx.maxCandidates {
+					break
+				}
 				ids[id] = struct{}{}
 			}
 		}
+		if idx.maxCandidates > 0 && len(ids) >= idx.maxCandidates {
+			break
+		}
 	}
-	out := make([]string, 0, len(ids))
+	out := make([]int, 0, len(ids))
 	for id := range ids {
 		out = append(out, id)
 	}
+	sort.Ints(out)
 	return out
 }
 
 // GetSignature returns the stored signature for a fragment ID
-func (idx *LSHIndex) GetSignature(id string) *MinHashSignature {
+func (idx *LSHIndex) GetSignature(id int) *MinHashSignature {
 	return idx.signatures[id]
 }
 
@@ -89,7 +109,7 @@ func (idx *LSHIndex) Rows() int {
 
 // Internal helpers
 
-func (idx *LSHIndex) addToBuckets(id string, sig *MinHashSignature) {
+func (idx *LSHIndex) addToBuckets(id int, sig *MinHashSignature) {
 	keys := idx.computeBandKeys(sig)
 	for _, k := range keys {
 		cur := idx.buckets[k]

--- a/internal/analyzer/lsh_index_test.go
+++ b/internal/analyzer/lsh_index_test.go
@@ -29,7 +29,7 @@ func TestAddFragment(t *testing.T) {
 	mh := NewMinHasher(128)
 
 	sig := mh.ComputeSignature([]string{"a", "b", "c"})
-	err := idx.AddFragment("frag1", sig)
+	err := idx.AddFragment(1, sig)
 	if err != nil {
 		t.Errorf("AddFragment failed: %v", err)
 	}
@@ -44,16 +44,16 @@ func TestAddFragmentErrors(t *testing.T) {
 	mh := NewMinHasher(128)
 
 	// Empty signature
-	err := idx.AddFragment("frag1", nil)
+	err := idx.AddFragment(1, nil)
 	if err == nil {
 		t.Error("Expected error for nil signature")
 	}
 
-	// Empty ID
+	// Negative ID
 	sig := mh.ComputeSignature([]string{"a", "b"})
-	err = idx.AddFragment("", sig)
+	err = idx.AddFragment(-1, sig)
 	if err == nil {
-		t.Error("Expected error for empty ID")
+		t.Error("Expected error for negative ID")
 	}
 }
 
@@ -66,21 +66,21 @@ func TestFindCandidates(t *testing.T) {
 	sig2 := mh.ComputeSignature([]string{"a", "b", "c", "x", "y"})
 	sig3 := mh.ComputeSignature([]string{"p", "q", "r", "s", "t"})
 
-	_ = idx.AddFragment("similar1", sig1)
-	_ = idx.AddFragment("similar2", sig2)
-	_ = idx.AddFragment("different", sig3)
+	_ = idx.AddFragment(1, sig1)
+	_ = idx.AddFragment(2, sig2)
+	_ = idx.AddFragment(3, sig3)
 
-	// Query with sig1 - should find similar2
+	// Query with sig1 - should find itself
 	candidates := idx.FindCandidates(sig1)
 
 	if len(candidates) == 0 {
 		t.Error("Expected at least one candidate")
 	}
 
-	// Should include similar1 (itself)
+	// Should include fragment 1 (itself)
 	found := false
 	for _, c := range candidates {
-		if c == "similar1" {
+		if c == 1 {
 			found = true
 			break
 		}
@@ -113,9 +113,9 @@ func TestGetSignature(t *testing.T) {
 	mh := NewMinHasher(128)
 
 	sig := mh.ComputeSignature([]string{"a", "b", "c"})
-	_ = idx.AddFragment("frag1", sig)
+	_ = idx.AddFragment(1, sig)
 
-	retrieved := idx.GetSignature("frag1")
+	retrieved := idx.GetSignature(1)
 	if retrieved == nil {
 		t.Error("Expected to retrieve signature")
 	}
@@ -124,7 +124,7 @@ func TestGetSignature(t *testing.T) {
 	}
 
 	// Non-existent
-	retrieved = idx.GetSignature("nonexistent")
+	retrieved = idx.GetSignature(999)
 	if retrieved != nil {
 		t.Error("Expected nil for non-existent ID")
 	}
@@ -147,8 +147,8 @@ func TestDuplicateAvoidance(t *testing.T) {
 	sig := mh.ComputeSignature([]string{"a", "b", "c"})
 
 	// Add same fragment twice
-	_ = idx.AddFragment("frag1", sig)
-	_ = idx.AddFragment("frag1", sig)
+	_ = idx.AddFragment(1, sig)
+	_ = idx.AddFragment(1, sig)
 
 	// Size should still be 1
 	if idx.Size() != 1 {
@@ -157,13 +157,13 @@ func TestDuplicateAvoidance(t *testing.T) {
 
 	// Candidates should not have duplicates
 	candidates := idx.FindCandidates(sig)
-	idCount := make(map[string]int)
+	idCount := make(map[int]int)
 	for _, c := range candidates {
 		idCount[c]++
 	}
 	for id, count := range idCount {
 		if count > 1 {
-			t.Errorf("Found duplicate candidate %s (count: %d)", id, count)
+			t.Errorf("Found duplicate candidate %d (count: %d)", id, count)
 		}
 	}
 }
@@ -186,9 +186,9 @@ func TestLSHSensitivity(t *testing.T) {
 
 	// Create index and add fragments
 	idx := NewLSHIndex(32, 4)
-	_ = idx.AddFragment("base", baseSig)
-	_ = idx.AddFragment("similar", similarSig)
-	_ = idx.AddFragment("different", differentSig)
+	_ = idx.AddFragment(1, baseSig)
+	_ = idx.AddFragment(2, similarSig)
+	_ = idx.AddFragment(3, differentSig)
 
 	// Query with similar signature
 	candidates := idx.FindCandidates(similarSig)
@@ -197,10 +197,10 @@ func TestLSHSensitivity(t *testing.T) {
 	hasBase := false
 	hasDifferent := false
 	for _, c := range candidates {
-		if c == "base" {
+		if c == 1 {
 			hasBase = true
 		}
-		if c == "different" {
+		if c == 3 {
 			hasDifferent = true
 		}
 	}
@@ -222,10 +222,88 @@ func TestLSHIndexWithManyFragments(t *testing.T) {
 			"common",
 		}
 		sig := mh.ComputeSignature(features)
-		_ = idx.AddFragment("frag_"+string(rune('0'+i%10))+string(rune('0'+i/10)), sig)
+		_ = idx.AddFragment(i, sig)
 	}
 
 	if idx.Size() != 100 {
 		t.Errorf("Expected 100 fragments, got %d", idx.Size())
+	}
+}
+
+func TestLSHIndexFindCandidatesKeepsOversizedBucketCandidates(t *testing.T) {
+	mh := NewMinHasher(128)
+	sig := mh.ComputeSignature([]string{"same", "feature", "set"})
+
+	lsh := NewLSHIndex(32, 4).WithMaxCandidates(2)
+	for _, id := range []int{1, 2, 3} {
+		if err := lsh.AddFragment(id, sig); err != nil {
+			t.Fatalf("add %d: %v", id, err)
+		}
+	}
+
+	cands := lsh.FindCandidates(sig)
+	if len(cands) != 2 {
+		t.Fatalf("expected oversized bucket candidates capped at 2; got %v", cands)
+	}
+}
+
+func TestLSHIndexFindCandidatesCapsTotalCandidates(t *testing.T) {
+	mh := NewMinHasher(128)
+	query := mh.ComputeSignature([]string{"shared", "query", "features"})
+
+	lsh := NewLSHIndex(32, 4).WithMaxCandidates(2)
+	keys := lsh.computeBandKeys(query)
+	lsh.buckets[keys[0]] = []int{1}
+	lsh.buckets[keys[1]] = []int{2}
+	lsh.buckets[keys[2]] = []int{3}
+
+	cands := lsh.FindCandidates(query)
+	if len(cands) > 2 {
+		t.Fatalf("expected candidates to be capped at 2; got %v", cands)
+	}
+}
+
+func TestLSHIndexFindCandidatesUsesDefaultCapAtBoundary(t *testing.T) {
+	mh := NewMinHasher(128)
+	sig := mh.ComputeSignature([]string{"same", "feature", "set"})
+
+	lsh := NewLSHIndex(32, 4)
+	for id := 0; id <= defaultLSHMaxCandidates; id++ {
+		if err := lsh.AddFragment(id, sig); err != nil {
+			t.Fatalf("add %d: %v", id, err)
+		}
+	}
+
+	cands := lsh.FindCandidates(sig)
+	if len(cands) != defaultLSHMaxCandidates {
+		t.Fatalf("candidate count mismatch: want %d got %d", defaultLSHMaxCandidates, len(cands))
+	}
+	for i, id := range cands {
+		if id != i {
+			t.Fatalf("candidate order mismatch at %d: got %d", i, id)
+		}
+	}
+}
+
+func TestLSHIndexFindCandidatesReturnsDeterministicIndexes(t *testing.T) {
+	mh := NewMinHasher(128)
+	sig := mh.ComputeSignature([]string{"same", "feature", "set"})
+
+	lsh := NewLSHIndex(32, 4)
+	for _, id := range []int{4, 2, 3, 1} {
+		if err := lsh.AddFragment(id, sig); err != nil {
+			t.Fatalf("add %d: %v", id, err)
+		}
+	}
+
+	cands := lsh.FindCandidates(sig)
+	want := []int{1, 2, 3, 4}
+	if len(cands) != len(want) {
+		t.Fatalf("candidate count mismatch: want %v got %v", want, cands)
+	}
+	for i := range want {
+		if cands[i] != want[i] {
+			t.Fatalf("candidate order mismatch: want %v got %v", want, cands)
+		}
 	}
 }

--- a/internal/analyzer/reachability.go
+++ b/internal/analyzer/reachability.go
@@ -29,13 +29,17 @@ type ReachabilityResult struct {
 
 // ReachabilityAnalyzer performs reachability analysis on CFGs
 type ReachabilityAnalyzer struct {
-	cfg *CFG
+	cfg                    *CFG
+	allPathsReturnCache    map[string]bool // cached results of allSuccessorsReturn
+	allPathsReturnComputed map[string]bool // tracks which blocks have been computed
 }
 
 // NewReachabilityAnalyzer creates a new reachability analyzer for the given CFG
 func NewReachabilityAnalyzer(cfg *CFG) *ReachabilityAnalyzer {
 	return &ReachabilityAnalyzer{
-		cfg: cfg,
+		cfg:                    cfg,
+		allPathsReturnCache:    make(map[string]bool),
+		allPathsReturnComputed: make(map[string]bool),
 	}
 }
 
@@ -226,24 +230,36 @@ func (ra *ReachabilityAnalyzer) allSuccessorsReturn(block *BasicBlock, visited m
 		return false
 	}
 
-	// Avoid infinite recursion
+	// Check cache first (memoization)
+	if ra.allPathsReturnComputed[block.ID] {
+		return ra.allPathsReturnCache[block.ID]
+	}
+
+	// Avoid infinite recursion (cycle detection)
 	if visited[block.ID] {
 		return false
 	}
 	visited[block.ID] = true
+	defer func() { visited[block.ID] = false }()
 
 	// If this block contains a return statement, it leads to return
 	if ra.blockContainsReturn(block) {
+		ra.allPathsReturnCache[block.ID] = true
+		ra.allPathsReturnComputed[block.ID] = true
 		return true
 	}
 
 	// If this is the exit block, it doesn't count as a return
 	if block == ra.cfg.Exit {
+		ra.allPathsReturnCache[block.ID] = false
+		ra.allPathsReturnComputed[block.ID] = true
 		return false
 	}
 
 	// If no successors, it's not a return path
 	if len(block.Successors) == 0 {
+		ra.allPathsReturnCache[block.ID] = false
+		ra.allPathsReturnComputed[block.ID] = true
 		return false
 	}
 
@@ -254,11 +270,15 @@ func (ra *ReachabilityAnalyzer) allSuccessorsReturn(block *BasicBlock, visited m
 			continue
 		}
 
-		if !ra.allSuccessorsReturn(edge.To, copyVisited(visited)) {
+		if !ra.allSuccessorsReturn(edge.To, visited) {
+			ra.allPathsReturnCache[block.ID] = false
+			ra.allPathsReturnComputed[block.ID] = true
 			return false
 		}
 	}
 
+	ra.allPathsReturnCache[block.ID] = true
+	ra.allPathsReturnComputed[block.ID] = true
 	return true
 }
 
@@ -278,7 +298,7 @@ func (ra *ReachabilityAnalyzer) markSuccessorsUnreachableAfterReturn(block *Basi
 				delete(result.ReachableBlocks, edge.To.ID)
 
 				// Recursively mark successors as unreachable
-				ra.markSuccessorsUnreachableAfterReturn(edge.To, result, copyVisited(visited))
+				ra.markSuccessorsUnreachableAfterReturn(edge.To, result, visited)
 			}
 		}
 	}
@@ -297,13 +317,4 @@ func (ra *ReachabilityAnalyzer) blockContainsReturn(block *BasicBlock) bool {
 	}
 
 	return false
-}
-
-// copyVisited creates a copy of the visited map to avoid sharing state between recursive calls
-func copyVisited(visited map[string]bool) map[string]bool {
-	copy := make(map[string]bool)
-	for k, v := range visited {
-		copy[k] = v
-	}
-	return copy
 }

--- a/internal/analyzer/reachability_test.go
+++ b/internal/analyzer/reachability_test.go
@@ -377,27 +377,102 @@ func TestReachabilityAnalyzer_blockContainsReturn(t *testing.T) {
 	}
 }
 
-func TestCopyVisited(t *testing.T) {
-	original := map[string]bool{
-		"a": true,
-		"b": false,
-		"c": true,
-	}
+func TestReachabilityAfterReturn(t *testing.T) {
+	assertUnreachable := func(t *testing.T, result *ReachabilityResult, block *BasicBlock) {
+		t.Helper()
 
-	copied := copyVisited(original)
-
-	// Check that copy has same values
-	for k, v := range original {
-		if copied[k] != v {
-			t.Errorf("Copied map should have same value for key %s", k)
+		if _, exists := result.UnreachableBlocks[block.ID]; !exists {
+			t.Fatalf("expected %s to be unreachable after return", block.ID)
+		}
+		if _, exists := result.ReachableBlocks[block.ID]; exists {
+			t.Fatalf("expected %s to be removed from reachable blocks", block.ID)
 		}
 	}
 
-	// Modify copy and ensure original is unchanged
-	copied["d"] = true
-	if _, exists := original["d"]; exists {
-		t.Error("Modifying copy should not affect original")
-	}
+	t.Run("ImmediateSuccessorMarkedUnreachable", func(t *testing.T) {
+		cfg := NewCFG("after_return")
+
+		returnBlock := cfg.CreateBlock("return_block")
+		deadBlock := cfg.CreateBlock("dead_block")
+
+		returnBlock.AddStatement(&parser.Node{Type: parser.NodeReturnStatement})
+		deadBlock.AddStatement(&parser.Node{Type: parser.NodeExpressionStatement})
+
+		cfg.Entry.AddSuccessor(returnBlock, EdgeNormal)
+		returnBlock.AddSuccessor(cfg.Exit, EdgeReturn)
+		returnBlock.AddSuccessor(deadBlock, EdgeNormal)
+		deadBlock.AddSuccessor(cfg.Exit, EdgeNormal)
+
+		analyzer := NewReachabilityAnalyzer(cfg)
+		result := analyzer.AnalyzeReachability()
+
+		assertUnreachable(t, result, deadBlock)
+		if !result.HasUnreachableCode() {
+			t.Fatal("expected unreachable code to be reported")
+		}
+
+		unreachableWithStatements := result.GetUnreachableBlocksWithStatements()
+		if len(unreachableWithStatements) != 1 || unreachableWithStatements[deadBlock.ID] == nil {
+			t.Fatalf("expected only %s to be reported as unreachable code, got %#v", deadBlock.ID, unreachableWithStatements)
+		}
+	})
+
+	t.Run("SharedDeadTailMarkedUnreachable", func(t *testing.T) {
+		cfg := NewCFG("after_return_shared_tail")
+
+		returnBlock := cfg.CreateBlock("return_block")
+		leftDead := cfg.CreateBlock("left_dead")
+		rightDead := cfg.CreateBlock("right_dead")
+		sharedDead := cfg.CreateBlock("shared_dead")
+		leafDead := cfg.CreateBlock("leaf_dead")
+
+		returnBlock.AddStatement(&parser.Node{Type: parser.NodeReturnStatement})
+		leftDead.AddStatement(&parser.Node{Type: parser.NodeReturnStatement})
+		rightDead.AddStatement(&parser.Node{Type: parser.NodeReturnStatement})
+		sharedDead.AddStatement(&parser.Node{Type: parser.NodeReturnStatement})
+		leafDead.AddStatement(&parser.Node{Type: parser.NodeExpressionStatement})
+
+		cfg.Entry.AddSuccessor(returnBlock, EdgeNormal)
+		returnBlock.AddSuccessor(cfg.Exit, EdgeReturn)
+		returnBlock.AddSuccessor(leftDead, EdgeNormal)
+		returnBlock.AddSuccessor(rightDead, EdgeNormal)
+		leftDead.AddSuccessor(sharedDead, EdgeNormal)
+		rightDead.AddSuccessor(sharedDead, EdgeNormal)
+		sharedDead.AddSuccessor(leafDead, EdgeNormal)
+		leafDead.AddSuccessor(cfg.Exit, EdgeNormal)
+
+		analyzer := NewReachabilityAnalyzer(cfg)
+		result := analyzer.AnalyzeReachability()
+
+		assertUnreachable(t, result, leftDead)
+		assertUnreachable(t, result, rightDead)
+		assertUnreachable(t, result, sharedDead)
+		assertUnreachable(t, result, leafDead)
+	})
+
+	t.Run("CyclicDeadTailMarkedUnreachable", func(t *testing.T) {
+		cfg := NewCFG("after_return_cycle")
+
+		returnBlock := cfg.CreateBlock("return_block")
+		deadA := cfg.CreateBlock("dead_a")
+		deadB := cfg.CreateBlock("dead_b")
+
+		returnBlock.AddStatement(&parser.Node{Type: parser.NodeReturnStatement})
+		deadA.AddStatement(&parser.Node{Type: parser.NodeReturnStatement})
+		deadB.AddStatement(&parser.Node{Type: parser.NodeReturnStatement})
+
+		cfg.Entry.AddSuccessor(returnBlock, EdgeNormal)
+		returnBlock.AddSuccessor(cfg.Exit, EdgeReturn)
+		returnBlock.AddSuccessor(deadA, EdgeNormal)
+		deadA.AddSuccessor(deadB, EdgeNormal)
+		deadB.AddSuccessor(deadA, EdgeNormal)
+
+		analyzer := NewReachabilityAnalyzer(cfg)
+		result := analyzer.AnalyzeReachability()
+
+		assertUnreachable(t, result, deadA)
+		assertUnreachable(t, result, deadB)
+	})
 }
 
 func TestReachabilityResult_AnalysisTime(t *testing.T) {

--- a/internal/parser/ast_builder.go
+++ b/internal/parser/ast_builder.go
@@ -100,6 +100,10 @@ func (b *ASTBuilder) buildNode(tsNode *sitter.Node) *Node {
 		return b.buildVariableDeclaration(tsNode)
 	case "expression_statement":
 		return b.buildExpressionStatement(tsNode)
+	case "empty_statement":
+		node := NewNode(NodeEmptyStatement)
+		node.Location = b.getLocation(tsNode)
+		return node
 	case "call_expression":
 		return b.buildCallExpression(tsNode)
 	case "member_expression":


### PR DESCRIPTION
## Summary

Final area (Misc) of the pyscn → jscan initial catch-up. Ports the cumulative diff up to pyscn `fb3fe92` into jscan, removes the catch-up section from SYNC.md, and moves the sync baseline to `fb3fe92`.

## Ported changes

| pyscn change | jscan files changed |
|---|---|
| LSH int fragment IDs + `WithMaxCandidates` (carried over from the clone area: `LSHMaxCandidates` config, default cap 1024, deterministic `sort.Ints` on candidates) | `internal/analyzer/lsh_index.go`, `clone_detector.go`, `lsh_index_test.go` |
| Memoized `allSuccessorsReturn` + removal of `copyVisited` (backtracking visited map instead of per-recursion copies) | `internal/analyzer/reachability.go`, `reachability_test.go` (ported `TestReachabilityAfterReturn`) |
| Lazy-import exclusion from circular dependency detection (#460, `6c9ddc8` / `88f7ed1` / `71e201a`) — the JS analog of Python function-body imports is dynamic `import()`, so `EdgeTypeDynamic` edges are skipped in the Tarjan traversal, chain building, path finding, and cycle-breaking suggestions. A pair that also has a static edge is still detected as a load-time cycle (same semantics as pyscn's "lazy only if every import is lazy" promotion rule) | `internal/analyzer/circular_detector.go`, `circular_detector_test.go` |
| Recalibrated coupling zone classification — Zone of Pain: D≥0.5 & Ca≥2 & I≤0.3 & A≤0.3; Zone of Uselessness: D≥0.5 & I≥0.7 & A≥0.7; main sequence: D≤0.2. Instability default thresholds changed from 0.2/0.8 to 0.3/0.7 (still configurable) | `internal/analyzer/coupling_metrics.go`, `domain/dependency_graph.go`, `coupling_metrics_test.go` |
| Dead code detection: merge contiguous same-reason findings (eliminates overlapping line ranges), EndLine tiebreak when StartLine is equal, and skip blocks consisting only of bare `;` (empty statements) as noise. To support the empty-statement check, tree-sitter `empty_statement` now maps to `NodeEmptyStatement` | `internal/analyzer/dead_code.go`, `internal/parser/ast_builder.go`, `dead_code_test.go` |
| Error codes TIMEOUT / CANCELLED / NOT_IMPLEMENTED / INTERNAL + constructors | `domain/errors.go` |
| `math/rand` nosemgrep annotation comment | (not applied — jscan does not run semgrep) |

## Skipped changes (recorded in SYNC.md "Pending changes")

- **`c324d2f` / `e912ca2` APTED DP-matrix reuse + parallel pair verification** — a large perf rework that landed in pyscn *after* the clone-area catch-up point (`73acc60`). Will be ported in a dedicated PR together with its worker-pool infrastructure (only the LSH int-ID part is ported here)
- **complexity.go AST-based statement metrics + CognitiveComplexity** — the core fix targets Python `match` decision-point double-counting; jscan counts JS branches its own way (logical/ternary operators), and cognitive complexity is an unported feature
- **cfg.go `ModuleNode` / `complexitySourceNode`** — unnecessary in jscan: the module-level CFG already sets `FunctionNode` to the Program node
- **`domain/defaults.go` constants refactor / `DefaultAnalysisIncludePatterns`** (domain/cbo.go, dead_code.go) — config-layer cleanup with Python file patterns; jscan keeps its own defaults
- **`DeadCodeResponse.Request` field** — analyze-config plumbing (already skipped as a category during the scoring catch-up)

## Verification

- `make test` passes (only pre-existing `TestBuildGraphWithDynamicImports` SKIP, present before this change)
- Golden comparison: ran `analyze --format json` before/after on `test-repos/latest-version` and `test-repos/junk`
  - Health score / grade unchanged for both repos (99/A)
  - `junk/index.js` left Zone of Pain (A=0.4 > 0.3) and `index.d.ts` left MainSequence (D=0.5 > 0.2) — both exactly as the new zone predicates dictate
  - `latest-version/index.js` stays in Zone of Pain under the new conditions (D=0.7, Ca=2, I=0, A=0.3)
  - The only other differences are function list enumeration order (pre-existing map-iteration nondeterminism)

🤖 Generated with [Claude Code](https://claude.com/claude-code)